### PR TITLE
Find missing templates used as partials

### DIFF
--- a/bin/update
+++ b/bin/update
@@ -18,6 +18,7 @@ $outputDir = __DIR__.'/../resources';
 $filesystem = new Filesystem();
 $wrapper = new GitWrapper();
 $wrapper->addOutputListener(new GitOutputStreamListener());
+$tokenizer = new Mustache_Tokenizer();
 
 if (false === is_dir($sourceDir)) {
     $repo = $wrapper->cloneRepository('git@github.com:elifesciences/pattern-library.git', $sourceDir);
@@ -69,6 +70,9 @@ $finder = (new Finder())->files()->in($patternDir)->name('*.yaml');
 $filesystem->remove($outputDir.'/definitions/');
 $filesystem->remove($outputDir.'/templates/');
 
+$foundTemplates = [];
+$resolvedTemplates = [];
+
 foreach ($finder as $file) {
     $yaml = Yaml::parse($file->getContents());
     $yaml = resolveJsonReferences($yaml, $file);
@@ -78,7 +82,29 @@ foreach ($finder as $file) {
     $filesystem->dumpFile($outputDir.'/definitions/'.$file->getFilename(), $yaml);
 
     $template = new SplFileInfo(substr($file->getRealPath(), 0, -4).'mustache');
+    $foundTemplates[] = $template->getFilename();
+
+    foreach ($tokenizer->scan(file_get_contents($template->getRealPath())) as $token) {
+        if (Mustache_Tokenizer::T_PARTIAL === $token['type']) {
+            $foundTemplates[] = explode('-', $token['name'], 2)[1].'.mustache';
+        }
+    }
+
     $filesystem->copy($template->getRealPath(), $outputDir.'/templates/'.$template->getFilename(), true);
+    $resolvedTemplates[] = $template->getFilename();
+}
+
+foreach (array_diff($foundTemplates, $resolvedTemplates) as $missingTemplate) {
+    $finder = (new Finder())->files()->in($patternDir)->name($missingTemplate);
+    if (0 === count($finder)) {
+        throw new Exception('Can\'t find template '.$missingTemplate);
+    } elseif (count($finder) > 1) {
+        throw new Exception('Found more than one template for '.$missingTemplate);
+    }
+
+    foreach ($finder as $template) {
+        $filesystem->copy($template->getRealPath(), $outputDir.'/templates/'.$template->getFilename(), true);
+    }
 }
 
 /**

--- a/resources/templates/investor-logos.mustache
+++ b/resources/templates/investor-logos.mustache
@@ -1,0 +1,27 @@
+
+<section class="investor-logos">
+
+  <div class="invester-logos__container">
+
+    <div class="investor-logos__img_container">
+      <picture class="investor-logos__picture">
+        <source srcset="{{assetsPath}}/img/logos/hhmi.svg" type="image/svg+xml">
+        <img src="{{assetsPath}}/img/logos/hhmi.png" alt="Howard Hughes Medical Institute" class="investor-logos__img" />
+      </picture>
+    </div>
+    <div class="investor-logos__img_container">
+      <picture class="investor-logos__picture">
+        <source srcset="{{assetsPath}}/img/logos/max.svg" type="image/svg+xml">
+        <img src="{{assetsPath}}/img/logos/max.png" alt="Max-Planck-Gesellschaft" class="investor-logos__img" />
+      </picture>
+    </div>
+    <div class="investor-logos__img_container">
+      <picture class="investor-logos__picture">
+        <source srcset="{{assetsPath}}/img/logos/wellcome.svg" type="image/svg+xml">
+        <img src="{{assetsPath}}/img/logos/wellcome.png" alt="Wellcome Trust" class="investor-logos__img" />
+      </picture>
+    </div>
+
+  </div>
+
+</section>

--- a/resources/templates/social-links.mustache
+++ b/resources/templates/social-links.mustache
@@ -1,0 +1,23 @@
+
+<div class="social-links">
+  <ul class="social-links__list">
+    <li class="social-links__list_item">
+      <a href="#" class="social-links__list_link social-links__list_link--facebook"><span class="visuallyhidden">Facebook</span></a>
+    </li>
+    <li class="social-links__list_item">
+      <a href="#" class="social-links__list_link social-links__list_link--gplus"><span class="visuallyhidden">Google+</span></a>
+    </li>
+    <li class="social-links__list_item">
+      <a href="#" class="social-links__list_link social-links__list_link--linkedin"><span class="visuallyhidden">LinkedIn</span></a>
+    </li>
+    <li class="social-links__list_item">
+      <a href="#" class="social-links__list_link social-links__list_link--twitter"><span class="visuallyhidden">Twitter</span></a>
+    </li>
+    <li class="social-links__list_item">
+      <a href="#" class="social-links__list_link social-links__list_link--medium"><span class="visuallyhidden">Medium</span></a>
+    </li>
+    <li class="social-links__list_item">
+      <a href="#" class="social-links__list_link social-links__list_link--flickr"><span class="visuallyhidden">Flickr</span></a>
+    </li>
+  </ul>
+</div>


### PR DESCRIPTION
The footer currently uses two partials which don't have definition files. This currently means that the templates aren't included in this library, so can't appear. We could create definition files for them, but in this case we might want to. So, this change will find any partials that don't have a definition file, and includes them.
