### PR TITLE
Add implementations for upstream testing

### DIFF
--- a/src/PatternRenderer/CallbackPatternRenderer.php
+++ b/src/PatternRenderer/CallbackPatternRenderer.php
@@ -1,0 +1,21 @@
+<?php
+
+namespace eLife\Patterns\PatternRenderer;
+
+use eLife\Patterns\PatternRenderer;
+use eLife\Patterns\ViewModel;
+
+final class CallbackPatternRenderer implements PatternRenderer
+{
+    private $callback;
+
+    public function __construct(callable $callback)
+    {
+        $this->callback = $callback;
+    }
+
+    public function render(ViewModel $viewModel) : string
+    {
+        return call_user_func($this->callback, $viewModel);
+    }
+}

--- a/src/ViewModel/FlexibleViewModel.php
+++ b/src/ViewModel/FlexibleViewModel.php
@@ -1,0 +1,88 @@
+<?php
+
+namespace eLife\Patterns\ViewModel;
+
+use ArrayObject;
+use BadMethodCallException;
+use eLife\Patterns\ViewModel;
+use Traversable;
+
+final class FlexibleViewModel implements ViewModel
+{
+    private $templateName;
+    private $properties;
+    private $styleSheets;
+    private $inlineStyleSheets;
+    private $javaScripts;
+    private $inlineJavaScripts;
+
+    public function __construct(
+        string $templateName,
+        array $properties,
+        Traversable $styleSheets = null,
+        Traversable $inlineStyleSheets = null,
+        Traversable $javaScripts = null,
+        Traversable $inlineJavaScripts = null
+    ) {
+        $this->templateName = $templateName;
+        $this->properties = $properties;
+        $this->styleSheets = $styleSheets ?? new ArrayObject();
+        $this->inlineStyleSheets = $inlineStyleSheets ?? new ArrayObject();
+        $this->javaScripts = $javaScripts ?? new ArrayObject();
+        $this->inlineJavaScripts = $inlineJavaScripts ?? new ArrayObject();
+    }
+
+    public function toArray() : array
+    {
+        return $this->properties;
+    }
+
+    public function offsetExists($offset)
+    {
+        return isset($this->properties[$offset]);
+    }
+
+    public function offsetGet($offset)
+    {
+        if ($this->offsetExists($offset)) {
+            return $this->properties[$offset];
+        }
+
+        return null;
+    }
+
+    public function offsetSet($offset, $value)
+    {
+        throw new BadMethodCallException('Object is immutable');
+    }
+
+    public function offsetUnset($offset)
+    {
+        throw new BadMethodCallException('Object is immutable');
+    }
+
+    public function getTemplateName() : string
+    {
+        return $this->templateName;
+    }
+
+    public function getStyleSheets() : Traversable
+    {
+        return $this->styleSheets;
+    }
+
+    public function getInlineStyleSheets() : Traversable
+    {
+        return $this->inlineStyleSheets;
+    }
+
+    public function getJavaScripts() : Traversable
+    {
+        return $this->javaScripts;
+    }
+
+    public function getInlineJavaScripts() : Traversable
+    {
+        return $this->inlineJavaScripts;
+    }
+}

--- a/tests/src/PatternRenderer/CallbackPatternRendererTest.php
+++ b/tests/src/PatternRenderer/CallbackPatternRendererTest.php
@@ -1,0 +1,42 @@
+<?php
+
+namespace tests\eLife\Patterns\PatternRenderer;
+
+use eLife\Patterns\PatternRenderer;
+use eLife\Patterns\PatternRenderer\CallbackPatternRenderer;
+use eLife\Patterns\ViewModel;
+use PHPUnit_Framework_TestCase;
+
+final class CallbackPatternRendererTest extends PHPUnit_Framework_TestCase
+{
+    /**
+     * @test
+     */
+    public function it_is_a_pattern_renderer()
+    {
+        $callback = function () {
+            return 'foo';
+        };
+        $patternRenderer = new CallbackPatternRenderer($callback);
+
+        $this->assertInstanceOf(PatternRenderer::class, $patternRenderer);
+    }
+
+    /**
+     * @test
+     */
+    public function it_renders_a_view_model()
+    {
+        $callback = function () {
+            return 'foo';
+        };
+        $patternRenderer = new CallbackPatternRenderer($callback);
+
+        $viewModel = $this->prophesize(ViewModel::class);
+        $viewModel->offsetExists('foo')->willReturn(true);
+        $viewModel->offsetGet('foo')->willReturn('bar');
+        $viewModel->getTemplateName()->willReturn('foo {{foo}}');
+
+        $this->assertSame('foo', $patternRenderer->render($viewModel->reveal()));
+    }
+}

--- a/tests/src/ViewModel/FlexibleViewModelTest.php
+++ b/tests/src/ViewModel/FlexibleViewModelTest.php
@@ -1,0 +1,112 @@
+<?php
+
+namespace tests\eLife\Patterns\ViewModel;
+
+use ArrayObject;
+use eLife\Patterns\CastsToArray;
+use function eLife\Patterns\flatten;
+use function eLife\Patterns\sanitise_traversable;
+use eLife\Patterns\ViewModel;
+use eLife\Patterns\ViewModel\FlexibleViewModel;
+use PHPUnit_Framework_TestCase;
+
+final class FlexibleViewModelTest extends PHPUnit_Framework_TestCase
+{
+    /**
+     * @test
+     */
+    public function it_is_a_view_model()
+    {
+        $viewModel = new FlexibleViewModel('/foo', ['bar' => 'baz']);
+
+        $this->assertInstanceOf(ViewModel::class, $viewModel);
+    }
+
+    /**
+     * @test
+     */
+    public function it_has_a_template()
+    {
+        $viewModel = new FlexibleViewModel('/foo', ['bar' => 'baz']);
+
+        $this->assertSame('/foo', $viewModel->getTemplateName());
+    }
+
+    /**
+     * @test
+     */
+    public function it_is_array_accessible()
+    {
+        $viewModel = new FlexibleViewModel('/foo', ['bar' => 'baz']);
+        $data = $viewModel->toArray();
+
+        foreach ($data as $key => $value) {
+            $actual = $this->handleValue($viewModel[$key]);
+
+            $this->assertSame($value, $actual);
+        }
+    }
+
+    /**
+     * @test
+     */
+    public function it_can_not_have_assets()
+    {
+        $viewModel = new FlexibleViewModel('/foo', ['bar' => 'baz']);
+
+        $this->assertEmpty($viewModel->getStyleSheets());
+        $this->assertEmpty($viewModel->getInlineStyleSheets());
+        $this->assertEmpty($viewModel->getJavaScripts());
+        $this->assertEmpty($viewModel->getInlineJavaScripts());
+    }
+
+    /**
+     * @test
+     */
+    public function it_can_have_assets()
+    {
+        $viewModel = new FlexibleViewModel(
+            '/foo',
+            ['bar' => 'baz'],
+            $styleSheets = new ArrayObject(['qux']),
+            $inlineStyleSheets = new ArrayObject(['quxx']),
+            $javaScripts = new ArrayObject(['corge']),
+            $inlineJavaScripts = new ArrayObject(['grault'])
+        );
+
+        $expectedStylesheets = iterator_to_array(sanitise_traversable($styleSheets));
+        $actualStyleSheets = iterator_to_array(sanitise_traversable($viewModel->getStyleSheets()));
+
+        $this->assertSame($expectedStylesheets, $actualStyleSheets);
+
+        $expectedInlineStylesheets = iterator_to_array(flatten($inlineStyleSheets));
+        $actualInlineStyleSheets = iterator_to_array(flatten($viewModel->getInlineStyleSheets()));
+
+        $this->assertSame($expectedInlineStylesheets, $actualInlineStyleSheets);
+
+        $expectedJavaScripts = iterator_to_array(sanitise_traversable($javaScripts));
+        $actualJavaScripts = iterator_to_array(sanitise_traversable($viewModel->getJavaScripts()));
+
+        $this->assertSame($expectedJavaScripts, $actualJavaScripts);
+
+        $expectedInlineJavaScripts = iterator_to_array(flatten($inlineJavaScripts));
+        $actualInlineJavaScripts = iterator_to_array(flatten($viewModel->getInlineJavaScripts()));
+
+        $this->assertSame($expectedInlineJavaScripts, $actualInlineJavaScripts);
+    }
+
+    private function handleValue($value)
+    {
+        if (is_array($value)) {
+            foreach ($value as $subKey => $subValue) {
+                $value[$subKey] = $this->handleValue($subValue);
+            }
+        }
+
+        if ($value instanceof CastsToArray) {
+            return $value->toArray();
+        }
+
+        return $value;
+    }
+}


### PR DESCRIPTION
This adds rather flexible implementations of `PatternRenderer` and `ViewModel` which can be used by tests outside of this library.
