### PR TITLE
Add SiteHeader view model and tests

### DIFF
--- a/resources/definitions/site-header.yaml
+++ b/resources/definitions/site-header.yaml
@@ -1,0 +1,248 @@
+assets:
+    css:
+        - site-header.css
+        -
+            - site-header-nav-bar-primary.css
+            - site-header-nav-bar-secondary.css
+    js: []
+schema:
+    $schema: 'http://json-schema.org/draft-04/schema#'
+    type: object
+    properties:
+        homePagePath:
+            type: string
+            minLength: 1
+        primaryLinks:
+            $schema: 'http://json-schema.org/draft-04/schema#'
+            type: object
+            properties:
+                classesOuter:
+                    type: string
+                classesInner:
+                    type: string
+                linkedItems:
+                    type: array
+                    items:
+                        $schema: 'http://json-schema.org/draft-04/schema#'
+                        type: object
+                        allOf:
+                            -
+                                properties:
+                                    classes:
+                                        type: string
+                            -
+                                oneOf:
+                                    -
+                                        properties:
+                                            text:
+                                                type: string
+                                                minLength: 1
+                                            textClasses:
+                                                type: string
+                                            path:
+                                                type: string
+                                                minLength: 1
+                                            rel:
+                                                type: string
+                                                enum:
+                                                    - search
+                                            img:
+                                                $schema: 'http://json-schema.org/draft-04/schema#'
+                                                type: object
+                                                properties:
+                                                    sources:
+                                                        type: array
+                                                        minItems: 1
+                                                        uniqueItems: true
+                                                        items:
+                                                            type: object
+                                                            properties:
+                                                                svg:
+                                                                    type: string
+                                                                    minLength: 1
+                                                                media:
+                                                                    type: string
+                                                                    minLength: 1
+                                                            required:
+                                                                - svg
+                                                    fallback:
+                                                        type: object
+                                                        properties:
+                                                            srcset:
+                                                                type: string
+                                                                pattern: '^((https)?[^ ]+ [1-9][0-9]*w)(, (https?)?[^ ]+ [1-9][0-9]*w)*$'
+                                                            defaultPath:
+                                                                type: string
+                                                                minLength: 1
+                                                            altText:
+                                                                type: string
+                                                            classes:
+                                                                type: string
+                                                        required:
+                                                            - srcset
+                                                            - defaultPath
+                                                            - altText
+                                                required:
+                                                    - sources
+                                                    - fallback
+                                        required:
+                                            - text
+                                            - path
+                                    -
+                                        properties:
+                                            button:
+                                                $schema: 'http://json-schema.org/draft-04/schema#'
+                                                type: object
+                                                allOf:
+                                                    -
+                                                        properties:
+                                                            text:
+                                                                type: string
+                                                                minLength: 1
+                                                            classes:
+                                                                type: string
+                                                        required:
+                                                            - text
+                                                    -
+                                                        oneOf:
+                                                            -
+                                                                properties:
+                                                                    type:
+                                                                        type: string
+                                                                        enum:
+                                                                            - button
+                                                                            - reset
+                                                                            - submit
+                                                                required:
+                                                                    - type
+                                                            -
+                                                                properties:
+                                                                    path:
+                                                                        type: string
+                                                                        minLength: 1
+                                                                required:
+                                                                    - path
+                                        required:
+                                            - button
+                    minItems: 1
+            required:
+                - linkedItems
+        secondaryLinks:
+            $schema: 'http://json-schema.org/draft-04/schema#'
+            type: object
+            properties:
+                classesOuter:
+                    type: string
+                classesInner:
+                    type: string
+                linkedItems:
+                    type: array
+                    items:
+                        $schema: 'http://json-schema.org/draft-04/schema#'
+                        type: object
+                        allOf:
+                            -
+                                properties:
+                                    classes:
+                                        type: string
+                            -
+                                oneOf:
+                                    -
+                                        properties:
+                                            text:
+                                                type: string
+                                                minLength: 1
+                                            textClasses:
+                                                type: string
+                                            path:
+                                                type: string
+                                                minLength: 1
+                                            rel:
+                                                type: string
+                                                enum:
+                                                    - search
+                                            img:
+                                                $schema: 'http://json-schema.org/draft-04/schema#'
+                                                type: object
+                                                properties:
+                                                    sources:
+                                                        type: array
+                                                        minItems: 1
+                                                        uniqueItems: true
+                                                        items:
+                                                            type: object
+                                                            properties:
+                                                                svg:
+                                                                    type: string
+                                                                    minLength: 1
+                                                                media:
+                                                                    type: string
+                                                                    minLength: 1
+                                                            required:
+                                                                - svg
+                                                    fallback:
+                                                        type: object
+                                                        properties:
+                                                            srcset:
+                                                                type: string
+                                                                pattern: '^((https)?[^ ]+ [1-9][0-9]*w)(, (https?)?[^ ]+ [1-9][0-9]*w)*$'
+                                                            defaultPath:
+                                                                type: string
+                                                                minLength: 1
+                                                            altText:
+                                                                type: string
+                                                            classes:
+                                                                type: string
+                                                        required:
+                                                            - srcset
+                                                            - defaultPath
+                                                            - altText
+                                                required:
+                                                    - sources
+                                                    - fallback
+                                        required:
+                                            - text
+                                            - path
+                                    -
+                                        properties:
+                                            button:
+                                                $schema: 'http://json-schema.org/draft-04/schema#'
+                                                type: object
+                                                allOf:
+                                                    -
+                                                        properties:
+                                                            text:
+                                                                type: string
+                                                                minLength: 1
+                                                            classes:
+                                                                type: string
+                                                        required:
+                                                            - text
+                                                    -
+                                                        oneOf:
+                                                            -
+                                                                properties:
+                                                                    type:
+                                                                        type: string
+                                                                        enum:
+                                                                            - button
+                                                                            - reset
+                                                                            - submit
+                                                                required:
+                                                                    - type
+                                                            -
+                                                                properties:
+                                                                    path:
+                                                                        type: string
+                                                                        minLength: 1
+                                                                required:
+                                                                    - path
+                                        required:
+                                            - button
+                    minItems: 1
+            required:
+                - linkedItems
+    required:
+        - homePagePath
+        - primaryLinks
+        - secondaryLinks

--- a/resources/templates/site-header.mustache
+++ b/resources/templates/site-header.mustache
@@ -1,0 +1,15 @@
+<header class="site-header clearfix" data-behaviour="SiteHeader" id="siteHeader">
+  <h1 class="site-header__title clearfix" role="banner"><a href="{{homePagePath}}" class="site-header__logo_link"><span class="visuallyhidden" >eLife home page</span></a></h1>
+  <div class="site-header__navigation" role="navigation" aria-label="Main navigation">
+
+    {{#secondaryLinks}}
+      {{> molecules-site-header-nav-bar }}
+    {{/secondaryLinks}}
+
+    {{#primaryLinks}}
+      {{> molecules-site-header-nav-bar }}
+    {{/primaryLinks}}
+
+  </div>
+  {{> molecules-search-box}}
+</header>

--- a/src/ViewModel/SiteHeader.php
+++ b/src/ViewModel/SiteHeader.php
@@ -1,0 +1,60 @@
+<?php
+
+namespace eLife\Patterns\ViewModel;
+
+use Assert\Assertion;
+use eLife\Patterns\ArrayFromProperties;
+use eLife\Patterns\ReadOnlyArrayAccess;
+use eLife\Patterns\SimplifyAssets;
+use eLife\Patterns\ViewModel;
+use Traversable;
+
+final class SiteHeader implements ViewModel
+{
+    use ArrayFromProperties;
+    use ReadOnlyArrayAccess;
+
+    private $homePagePath;
+    private $primaryLinks;
+    private $secondaryLinks;
+
+    public function __construct(string $homePagePath, SiteHeaderNavBar $primaryLinks, SiteHeaderNavBar $secondaryLinks)
+    {
+        Assertion::notBlank($homePagePath);
+
+        $this->homePagePath = $homePagePath;
+        $this->primaryLinks = $primaryLinks;
+        $this->secondaryLinks = $secondaryLinks;
+    }
+
+    public function getStyleSheets() : Traversable
+    {
+        yield '/elife/patterns/assets/css/site-header.css';
+        yield $this->primaryLinks->getStyleSheets();
+        yield $this->secondaryLinks->getStyleSheets();
+    }
+
+    public function getInlineStyleSheets() : Traversable
+    {
+        yield $this->primaryLinks->getInlineStyleSheets();
+        yield $this->secondaryLinks->getInlineStyleSheets();
+    }
+
+    public function getJavaScripts() : Traversable
+    {
+        yield $this->primaryLinks->getJavaScripts();
+        yield $this->secondaryLinks->getJavaScripts();
+    }
+
+    public function getInlineJavaScripts() : Traversable
+    {
+        yield $this->primaryLinks->getInlineJavaScripts();
+        yield $this->secondaryLinks->getInlineJavaScripts();
+    }
+
+    public function getTemplateName() : string
+    {
+        return '/elife/patterns/templates/site-header.mustache';
+    }
+
+}

--- a/tests/src/ViewModel/SiteHeaderTest.php
+++ b/tests/src/ViewModel/SiteHeaderTest.php
@@ -1,0 +1,100 @@
+<?php
+
+namespace tests\eLife\Patterns\ViewModel;
+
+use eLife\Patterns\ViewModel\Button;
+use eLife\Patterns\ViewModel\NavLinkedItem;
+use eLife\Patterns\ViewModel\SiteHeader;
+use eLife\Patterns\ViewModel\SiteHeaderNavBar;
+use InvalidArgumentException;
+use TypeError;
+
+final class SiteHeaderTest extends ViewModelTest
+{
+    private $homePagePath;
+    private $primaryLinks;
+    private $secondaryLinks;
+
+    public function setUp()
+    {
+        parent::setUp();
+        $this->homePagePath = '/home/page/path';
+        $this->primaryLinks = SiteHeaderNavBar::primary(
+          [
+            NavLinkedItem::asLink('text-first', '/path/first', [], [], false),
+            NavLinkedItem::asLink('text-second', '/path/second', [], [], true),
+          ]
+        );
+
+        $this->secondaryLinks = SiteHeaderNavBar::secondary(
+          [
+            NavLinkedItem::asLink('text-first', '/path/first', [], [], false),
+            NavLinkedItem::asButton(Button::link('button text', '/button/path'), []),
+          ]
+        );
+    }
+
+    /**
+     * @test
+     */
+    public function it_has_data()
+    {
+        $siteHeader = new SiteHeader($this->homePagePath, $this->primaryLinks, $this->secondaryLinks);
+        $this->assertSame($this->homePagePath, $siteHeader['homePagePath']);
+        $this->assertSame($this->primaryLinks, $siteHeader['primaryLinks']);
+        $this->assertSame($this->secondaryLinks, $siteHeader['secondaryLinks']);
+    }
+
+    /**
+     * @test
+     */
+    public function home_page_path_must_not_be_blank()
+    {
+        $this->expectException(InvalidArgumentException::class);
+        new SiteHeader('', $this->primaryLinks, $this->secondaryLinks);
+    }
+
+    /**
+     * @test
+     */
+    public function primary_links_must_be_supplied()
+    {
+        $this->expectException(TypeError::class);
+        new SiteHeader($this->homePagePath, null, $this->secondaryLinks);
+    }
+
+    /**
+     * @test
+     */
+    public function secondary_links_must_be_supplied()
+    {
+        $this->expectException(TypeError::class);
+        new SiteHeader($this->homePagePath, $this->primaryLinks, null);
+    }
+
+    public function viewModelProvider() : array
+    {
+        $primaryLinks = SiteHeaderNavBar::primary(
+          [
+            NavLinkedItem::asLink('text-first', '/path/first', [], [], false),
+            NavLinkedItem::asLink('text-second', '/path/second', [], [], true),
+          ]
+        );
+
+        $secondaryLinks = SiteHeaderNavBar::secondary(
+          [
+            NavLinkedItem::asLink('text-first', '/path/first', [], [], false),
+            NavLinkedItem::asButton(Button::link('button text', '/button/path'), []),
+          ]
+        );
+
+        return [
+            [new SiteHeader('/home/page/path', $primaryLinks, $secondaryLinks)],
+        ];
+    }
+
+    protected function expectedTemplate() : string
+    {
+        return '/elife/patterns/templates/site-header.mustache';
+    }
+}


### PR DESCRIPTION
This leaves in the unspecified partial `{{> molecules-search-box}}` in the mustache template. If it can be safely left but ignored, I can add a code comment explaining it; if it needs to come out in order to stop things breaking, I'll think about how we handle things wrt coordination in pattern lab.
