### PR TITLE
Abstract button classes

### DIFF
--- a/src/ViewModel/Button.php
+++ b/src/ViewModel/Button.php
@@ -11,6 +11,13 @@ use Traversable;
 
 final class Button implements ViewModel
 {
+    const SIZE_MEDIUM = 'medium';
+    const SIZE_SMALL = 'small';
+    const SIZE_EXTRA_SMALL = 'extra-small';
+
+    const STYLE_DEFAULT = 'default';
+    const STYLE_OUTLINE = 'outline';
+
     const TYPE_BUTTON = 'button';
     const TYPE_SUBMIT = 'submit';
     const TYPE_RESET = 'reset';
@@ -24,29 +31,63 @@ final class Button implements ViewModel
     private $text;
     private $type;
 
-    private function __construct(string $text, array $classes = [])
+    private function __construct(string $text, string $size, string $style, bool $isActive, bool $isFullWidth = true)
     {
         Assertion::notBlank($text);
+        Assertion::choice($size, [self::SIZE_MEDIUM, self::SIZE_SMALL, self::SIZE_EXTRA_SMALL]);
+        Assertion::choice($style, [self::STYLE_DEFAULT, self::STYLE_OUTLINE]);
+
+        $classes = [];
+
+        if (self::SIZE_MEDIUM !== $size) {
+            $classes[] = 'button--'.$size;
+        }
+
+        if (self::STYLE_OUTLINE === $style && false === $isActive) {
+            $classes[] = 'button--outline-inactive';
+        } else {
+            $classes[] = 'button--'.$style;
+
+            if (false === $isActive) {
+                $classes[] = 'button--inactive';
+            }
+        }
+
+        if (true === $isFullWidth) {
+            $classes[] = 'button--full';
+        }
 
         $this->text = $text;
         $this->classes = implode(' ', $classes);
     }
 
-    public static function form(string $text, string $type, array $classes = []) : Button
-    {
+    public static function form(
+        string $text,
+        string $type,
+        string $size = self::SIZE_MEDIUM,
+        string $style = self::STYLE_DEFAULT,
+        bool $isActive = true,
+        bool $isFullWidth = false
+    ) : Button {
         Assertion::choice($type, [self::TYPE_BUTTON, self::TYPE_SUBMIT, self::TYPE_RESET]);
 
-        $button = new static($text, $classes);
+        $button = new static($text, $size, $style, $isActive, $isFullWidth);
         $button->type = $type;
 
         return $button;
     }
 
-    public static function link(string $text, string $path, array $classes = []) : Button
-    {
+    public static function link(
+        string $text,
+        string $path,
+        string $size = self::SIZE_MEDIUM,
+        string $style = self::STYLE_DEFAULT,
+        bool $isActive = true,
+        bool $isFullWidth = false
+    ) : Button {
         Assertion::notBlank($path);
 
-        $button = new static($text, $classes);
+        $button = new static($text, $size, $style, $isActive, $isFullWidth);
         $button->path = $path;
 
         return $button;

--- a/tests/src/ViewModel/ButtonNavLinkedItemTest.php
+++ b/tests/src/ViewModel/ButtonNavLinkedItemTest.php
@@ -13,7 +13,7 @@ final class ButtonNavLinkedItemTest extends ViewModelTest
     public function setUp()
     {
         parent::setUp();
-        $this->button = Button::link('the button text', '/the/button/path', ['button-class-1', 'button-class-2']);
+        $this->button = Button::link('the button text', '/the/button/path');
     }
 
     /**
@@ -43,7 +43,7 @@ final class ButtonNavLinkedItemTest extends ViewModelTest
 
     public function viewModelProvider() : array
     {
-        $button = Button::link('the button text', '/the/button/path', ['button-class-1', 'button-class-2']);
+        $button = Button::link('the button text', '/the/button/path');
 
         return [
           'basic' => [NavLinkedItem::asButton($button)],

--- a/tests/src/ViewModel/FormButtonTest.php
+++ b/tests/src/ViewModel/FormButtonTest.php
@@ -13,17 +13,27 @@ final class FormButtonTest extends ViewModelTest
     public function it_has_data()
     {
         $data = [
-            'classes' => 'class1 class2',
+            'classes' => 'button--small button--outline button--full',
             'text' => 'text',
             'type' => Button::TYPE_BUTTON,
         ];
 
-        $button = Button::form('text', Button::TYPE_BUTTON, ['class1', 'class2']);
+        $button = Button::form('text', Button::TYPE_BUTTON, Button::SIZE_SMALL, Button::STYLE_OUTLINE, true, true);
 
         $this->assertSame($data['text'], $button['text']);
         $this->assertSame($data['type'], $button['type']);
         $this->assertSame($data['classes'], $button['classes']);
         $this->assertSame($data, $button->toArray());
+    }
+
+    /**
+     * @test
+     */
+    public function it_merges_outline_and_inactive_states()
+    {
+        $button = Button::form('text', Button::TYPE_BUTTON, Button::SIZE_MEDIUM, Button::STYLE_OUTLINE, false);
+
+        $this->assertSame('button--outline-inactive', $button['classes']);
     }
 
     /**
@@ -46,11 +56,41 @@ final class FormButtonTest extends ViewModelTest
         Button::form('text', 'foo');
     }
 
+    /**
+     * @test
+     */
+    public function it_cannot_have_an_invalid_size()
+    {
+        $this->expectException(InvalidArgumentException::class);
+
+        Button::form('text', Button::TYPE_BUTTON, 'foo');
+    }
+
+    /**
+     * @test
+     */
+    public function it_cannot_have_an_invalid_style()
+    {
+        $this->expectException(InvalidArgumentException::class);
+
+        Button::form('text', Button::TYPE_BUTTON, Button::SIZE_MEDIUM, 'foo');
+    }
+
     public function viewModelProvider() : array
     {
         return [
-            'without class' => [Button::form('text', Button::TYPE_BUTTON)],
-            'with class' => [Button::form('text', Button::TYPE_BUTTON, ['class'])],
+            'button' => [Button::form('text', Button::TYPE_BUTTON)],
+            'reset' => [Button::form('text', Button::TYPE_RESET)],
+            'submit' => [Button::form('text', Button::TYPE_SUBMIT)],
+            'small' => [Button::form('text', Button::TYPE_BUTTON, Button::SIZE_SMALL)],
+            'extra small' => [Button::form('text', Button::TYPE_BUTTON, Button::SIZE_SMALL)],
+            'outline' => [Button::form('text', Button::TYPE_BUTTON, Button::SIZE_MEDIUM, Button::STYLE_OUTLINE)],
+            'inactive' => [
+                Button::form('text', Button::TYPE_BUTTON, Button::SIZE_MEDIUM, Button::STYLE_DEFAULT, false),
+            ],
+            'full width' => [
+                Button::form('text', Button::TYPE_BUTTON, Button::SIZE_MEDIUM, Button::STYLE_DEFAULT, true, true),
+            ],
         ];
     }
 

--- a/tests/src/ViewModel/LinkButtonTest.php
+++ b/tests/src/ViewModel/LinkButtonTest.php
@@ -13,17 +13,27 @@ final class LinkButtonTest extends ViewModelTest
     public function it_has_data()
     {
         $data = [
-            'classes' => 'class1 class2',
+            'classes' => 'button--small button--outline button--full',
             'path' => 'path',
             'text' => 'text',
         ];
 
-        $button = Button::link('text', 'path', ['class1', 'class2']);
+        $button = Button::link('text', 'path', Button::SIZE_SMALL, Button::STYLE_OUTLINE, true, true);
 
         $this->assertSame($data['text'], $button['text']);
         $this->assertSame($data['path'], $button['path']);
         $this->assertSame($data['classes'], $button['classes']);
         $this->assertSame($data, $button->toArray());
+    }
+
+    /**
+     * @test
+     */
+    public function it_merges_outline_and_inactive_states()
+    {
+        $button = Button::link('text', 'path', Button::SIZE_MEDIUM, Button::STYLE_OUTLINE, false);
+
+        $this->assertSame('button--outline-inactive', $button['classes']);
     }
 
     /**
@@ -46,11 +56,35 @@ final class LinkButtonTest extends ViewModelTest
         Button::link('text', '');
     }
 
+    /**
+     * @test
+     */
+    public function it_cannot_have_an_invalid_size()
+    {
+        $this->expectException(InvalidArgumentException::class);
+
+        Button::link('text', 'path', Button::TYPE_BUTTON, 'foo');
+    }
+
+    /**
+     * @test
+     */
+    public function it_cannot_have_an_invalid_style()
+    {
+        $this->expectException(InvalidArgumentException::class);
+
+        Button::link('text', 'path', Button::TYPE_BUTTON, Button::SIZE_MEDIUM, 'foo');
+    }
+
     public function viewModelProvider() : array
     {
         return [
-            'without class' => [Button::link('text', 'path')],
-            'with class' => [Button::link('text', 'path', ['class'])],
+            'button' => [Button::link('text', 'path')],
+            'small' => [Button::link('text', 'path', Button::SIZE_SMALL)],
+            'extra small' => [Button::link('text', 'path', Button::SIZE_SMALL)],
+            'outline' => [Button::link('text', 'path', Button::SIZE_MEDIUM, Button::STYLE_OUTLINE)],
+            'inactive' => [Button::link('text', 'path', Button::SIZE_MEDIUM, Button::STYLE_DEFAULT, false)],
+            'full width' => [Button::link('text', 'path', Button::SIZE_MEDIUM, Button::STYLE_DEFAULT, true, true)],
         ];
     }
 

--- a/tests/src/ViewModel/SecondarySiteHeaderNavBarTest.php
+++ b/tests/src/ViewModel/SecondarySiteHeaderNavBarTest.php
@@ -28,7 +28,7 @@ final class SecondarySiteHeaderNavBarTest extends ViewModelTest
           new Image('/path/to/fallback/', [500 => '/path/in/srcset'], 'alt text', [])
         );
 
-        $this->button = Button::form('button text', 'button', ['button-class-1', 'button-class-2']);
+        $this->button = Button::form('button text', 'button');
 
         $this->linkItem1 = NavLinkedItem::asLink('item 1', '/item-1/', ['class-1'], ['text-class-1'], false, $this->img);
         $this->linkItem2 = NavLinkedItem::asLink('item 2', '/item-2/', ['class-2'], ['text-class-2'], false);
@@ -84,7 +84,7 @@ final class SecondarySiteHeaderNavBarTest extends ViewModelTest
             new Image('/path/to/fallback/', [500 => '/path/in/srcset'], 'alt text', [])
         );
 
-        $button = Button::form('button text', 'button', ['button-class-1', 'button-class-2']);
+        $button = Button::form('button text', 'button');
 
         $navLinkItems = [
           NavLinkedItem::asLink('item 1', '/item-1/', ['class-1'], ['text-class-1'], false, $img),


### PR DESCRIPTION
Current the end user has to manually add in button classes. This abstracts the various classes, so that they instead define what functionality they want, without having to know the classes.
