### PR TITLE
Generate the main menu link ID

### DIFF
--- a/src/ViewModel/MainMenuLink.php
+++ b/src/ViewModel/MainMenuLink.php
@@ -23,7 +23,7 @@ final class MainMenuLink implements CastsToArray
         Assertion::allIsInstanceOf($items, Link::class);
 
         $this->title = $title;
-        $this->titleId = 'mainMenu'.$title;
+        $this->titleId = 'mainMenu'.hash('crc32', $title);
         $this->items = $items;
     }
 }

--- a/tests/src/ViewModel/FooterTest.php
+++ b/tests/src/ViewModel/FooterTest.php
@@ -20,7 +20,7 @@ final class FooterTest extends ViewModelTest
             'mainMenuLinks' => [
                 [
                     'title' => 'title',
-                    'titleId' => 'mainMenutitle',
+                    'titleId' => 'mainMenu'.hash('crc32', 'title'),
                     'items' => [['name' => 'name1', 'url' => 'url1']],
                 ],
             ],

--- a/tests/src/ViewModel/MainMenuLinkTest.php
+++ b/tests/src/ViewModel/MainMenuLinkTest.php
@@ -25,7 +25,7 @@ final class MainMenuLinkTest extends PHPUnit_Framework_TestCase
      */
     public function it_has_data()
     {
-        $data = ['title' => 'title', 'titleId' => 'mainMenutitle', 'items' => [['name' => 'name', 'url' => 'url']]];
+        $data = ['title' => 'title', 'titleId' => 'mainMenu'.hash('crc32', 'title'), 'items' => [['name' => 'name', 'url' => 'url']]];
 
         $mainMenuLink = new MainMenuLink($data['title'],
             $items = [new Link($data['items'][0]['name'], $data['items'][0]['url'])]);

--- a/tests/src/ViewModel/MainMenuTest.php
+++ b/tests/src/ViewModel/MainMenuTest.php
@@ -17,7 +17,7 @@ final class MainMenuTest extends ViewModelTest
             'mainMenuLinks' => [
                 [
                     'title' => 'title',
-                    'titleId' => 'mainMenutitle',
+                    'titleId' => 'mainMenu'.hash('crc32', 'title'),
                     'items' => [['name' => 'name', 'url' => 'url']],
                 ],
             ],


### PR DESCRIPTION
There doesn't look to be a need for the end user to set an ID. This is a simple generation that assumes that there's not two entries with the same title.
