### PR TITLE
Don't allow image classes to be manually set

### DIFF
--- a/src/ViewModel/Image.php
+++ b/src/ViewModel/Image.php
@@ -13,17 +13,15 @@ final class Image implements CastsToArray
     use ReadOnlyArrayAccess;
 
     private $altText;
-    private $classes;
     private $defaultPath;
     private $srcset;
 
-    public function __construct(string $defaultPath, array $srcset, string $altText = '', array $classes = [])
+    public function __construct(string $defaultPath, array $srcset, string $altText = '')
     {
         Assertion::notBlank($defaultPath);
         Assertion::notEmpty($srcset);
         Assertion::allInteger(array_keys($srcset));
         Assertion::allNotBlank($srcset);
-        Assertion::allString($classes);
 
         $this->defaultPath = $defaultPath;
         $this->srcset = [];
@@ -32,13 +30,5 @@ final class Image implements CastsToArray
         }
         $this->srcset = implode(', ', $this->srcset);
         $this->altText = $altText;
-        $this->classes = implode(' ', $classes);
-    }
-
-    public function addClass($className)
-    {
-        $this->classes = trim($this->classes.' '.$className);
-
-        return $this;
     }
 }

--- a/src/ViewModel/Picture.php
+++ b/src/ViewModel/Picture.php
@@ -14,11 +14,10 @@ final class Picture implements ViewModel
     use ReadOnlyArrayAccess;
     use SimplifyAssets;
 
-    private $pictureClasses;
     private $fallback;
     private $sources;
 
-    public function __construct(array $sources, Image $fallback, string $pictureClasses = null)
+    public function __construct(array $sources, Image $fallback)
     {
         Assertion::notEmpty($sources);
         $nullMediaCount = 0;
@@ -32,21 +31,6 @@ final class Picture implements ViewModel
 
         $this->sources = $sources;
         $this->fallback = $fallback;
-        $this->pictureClasses = $pictureClasses;
-    }
-
-    public function addPictureClass(string $class) : Picture
-    {
-        $this->pictureClasses = trim($this->pictureClasses.' '.$class);
-
-        return $this;
-    }
-
-    public function addFallbackClass(string $classes) : Picture
-    {
-        $this->fallback->addClass($classes);
-
-        return $this;
     }
 
     public function getTemplateName() : string

--- a/src/ViewModel/ProfileSnippet.php
+++ b/src/ViewModel/ProfileSnippet.php
@@ -32,11 +32,16 @@ final class ProfileSnippet implements ViewModel
         $this->setPicture($picture);
     }
 
-    protected function setPicture(Picture $picture)
+    private function setPicture(Picture $picture)
     {
+        $picture = FlexibleViewModel::fromViewModel($picture);
+
+        $fallback = $picture['fallback'];
+        $fallback['classes'] = static::FALLBACK_CLASSES;
+
         $this->picture = $picture
-            ->addPictureClass(static::PICTURE_CLASSES)
-            ->addFallbackClass(static::FALLBACK_CLASSES)
+            ->withProperty('pictureClasses', self::PICTURE_CLASSES)
+            ->withProperty('fallback', $fallback)
         ;
     }
 

--- a/tests/src/ViewModel/CaptionedImageTest.php
+++ b/tests/src/ViewModel/CaptionedImageTest.php
@@ -23,7 +23,6 @@ final class CaptionedImageTest extends ViewModelTest
             'picture' => [
                     'fallback' => [
                             'altText' => 'the alt text',
-                            'classes' => '',
                             'defaultPath' => '/default/path',
                             'srcset' => '/path/to/image/'.$widthFirst.'/wide '.$widthFirst.'w, /default/path '.$widthSecond.'w',
                         ],

--- a/tests/src/ViewModel/ImageTest.php
+++ b/tests/src/ViewModel/ImageTest.php
@@ -26,7 +26,6 @@ final class ImageTest extends PHPUnit_Framework_TestCase
     {
         $data = [
             'altText' => 'altText',
-            'classes' => '',
             'defaultPath' => '/foo.png',
             'srcset' => '/bar.png 10w, /baz.png 20w',
         ];
@@ -37,21 +36,6 @@ final class ImageTest extends PHPUnit_Framework_TestCase
         $this->assertSame($data['srcset'], $image['srcset']);
         $this->assertSame($data['altText'], $image['altText']);
         $this->assertSame($data, $image->toArray());
-
-        $dataWithClasses = [
-          'altText' => 'altText',
-          'classes' => 'class-1 class-2',
-          'defaultPath' => '/foo.png',
-          'srcset' => '/bar.png 10w, /baz.png 20w',
-        ];
-
-        $imageWithClasses = new Image('/foo.png', [10 => '/bar.png', 20 => '/baz.png'], 'altText', ['class-1', 'class-2']);
-
-        $this->assertSame($dataWithClasses['defaultPath'], $imageWithClasses['defaultPath']);
-        $this->assertSame($dataWithClasses['srcset'], $imageWithClasses['srcset']);
-        $this->assertSame($dataWithClasses['altText'], $imageWithClasses['altText']);
-        $this->assertSame($dataWithClasses['classes'], $imageWithClasses['classes']);
-        $this->assertSame($dataWithClasses, $imageWithClasses->toArray());
     }
 
     /**

--- a/tests/src/ViewModel/PictureTest.php
+++ b/tests/src/ViewModel/PictureTest.php
@@ -27,7 +27,6 @@ final class PictureTest extends ViewModelTest
         $data = [
           'fallback' => [
             'altText' => 'the alt text',
-            'classes' => 'class-1 class-2',
             'defaultPath' => '/default/path',
             'srcset' => '/path/to/image/500/wide 500w, /default/path 250w',
           ],
@@ -45,7 +44,6 @@ final class PictureTest extends ViewModelTest
         $picture = new Picture($data['sources'], $this->imageFixture);
         $this->assertSame($data['fallback']['defaultPath'], $picture['fallback']['defaultPath']);
         $this->assertSame($data['fallback']['altText'], $picture['fallback']['altText']);
-        $this->assertSame($data['fallback']['classes'], $picture['fallback']['classes']);
         $this->assertSame($data['sources'], $picture['sources']);
         $this->assertSame($data, $picture->toArray());
     }
@@ -57,50 +55,6 @@ final class PictureTest extends ViewModelTest
     {
         $this->expectException(InvalidArgumentException::class);
         new Picture([], $this->imageFixture);
-    }
-
-    /**
-     * @test
-     */
-    public function it_can_have_additional_picture_classes_added()
-    {
-        $picture = new Picture([
-            [
-                'srcset' => '/path/to/svg',
-            ],
-            [
-                'srcset' => '/path/to/another/svg',
-                'media' => 'media statement',
-            ],
-        ], $this->imageFixture, 'firstPictureClass');
-
-        $picture->addPictureClass('secondPictureClass');
-        $picture->addPictureClass('thirdPictureClass ');
-        $this->assertSame('firstPictureClass secondPictureClass thirdPictureClass', $picture['pictureClasses']);
-    }
-
-    /**
-     * @test
-     */
-    public function it_can_have_additional_fallback_image_classes_added()
-    {
-        $picture = new Picture([
-            [
-                'srcset' => '/path/to/svg',
-            ],
-            [
-                'srcset' => '/path/to/another/svg',
-                'media' => 'media statement',
-            ],
-        ], new Image(
-            '/default/path',
-            [500 => '/path/to/image/500/wide', 250 => '/default/path'],
-            'the alt text',
-            ['firstFallbackPictureClass']));
-
-        $picture->addFallbackClass('secondFallbackPictureClass');
-        $picture->addFallbackClass('thirdFallbackPictureClass ');
-        $this->assertSame('firstFallbackPictureClass secondFallbackPictureClass thirdFallbackPictureClass', $picture['fallback']['classes']);
     }
 
     /**

--- a/tests/src/ViewModel/ProfileSnippetTest.php
+++ b/tests/src/ViewModel/ProfileSnippetTest.php
@@ -15,18 +15,18 @@ final class ProfileSnippetTest extends ViewModelTest
     {
         $data = [
             'picture' => [
-                    'pictureClasses' => 'profile-snippet__picture',
                     'fallback' => [
                             'altText' => 'the alt text',
-                            'classes' => 'profile-snippet__image',
                             'defaultPath' => '/default/path',
                             'srcset' => '/path/to/image/500/wide 500w, /default/path 250w',
+                            'classes' => 'profile-snippet__image',
                         ],
                     'sources' => [
                             0 => [
                                     'srcset' => '/path/to/svg',
                                 ],
                         ],
+                    'pictureClasses' => 'profile-snippet__picture',
                 ],
             'title' => 'Title McTitle',
             'name' => 'Name McName',

--- a/tests/src/ViewModel/ViewerInlineTest.php
+++ b/tests/src/ViewModel/ViewerInlineTest.php
@@ -31,7 +31,6 @@ class ViewerInlineTest extends ViewModelTest
                 'picture' => [
                     'fallback' => [
                         'altText' => 'the alt text',
-                        'classes' => '',
                         'defaultPath' => '/default/path',
                         'srcset' => '/path/to/image/500/wide 500w, /default/path 250w',
                     ],


### PR DESCRIPTION
This removes the ability to set classes on `Image` and `Picture`, as we shouldn't need it (it also reverts them to be immutable, though that could have been fixed by using withers rather than adders). `ProfileSnippet`, which needs specific classes set, now turns them into a `FlexibleViewModel` and adds classes to that instead. This means that `Image` and `Picture` don't know about the `classes` and `pictureClasses` properties respectively. (The schema for `ProfileSnippet` _does_ know about them.)

Ping @stephenwf and @davidcmoulton.
