### PR TITLE
[WIP] Attempt to programatically set icon css classes on picture's fallback image

### DIFF
--- a/src/ViewModel/NavLinkedItem.php
+++ b/src/ViewModel/NavLinkedItem.php
@@ -13,8 +13,13 @@ final class NavLinkedItem implements ViewModel
     use ReadOnlyArrayAccess;
     use SimplifyAssets;
 
+    const ICON_CLASSES = [
+        'menu' => 'nav-primary__menu_icon',
+        'search' => 'nav-primary__search_icon',
+    ];
+
     private $button;
-    private $img;
+    public $picture;
     private $path;
     private $rel;
     private $text;
@@ -25,18 +30,37 @@ final class NavLinkedItem implements ViewModel
     }
 
     public static function asIcon(
-        Link $link,
-        Picture $img,
-        bool $showText = true,
-        bool $search = false
-    ): NavLinkedItem {
+      Link $link,
+      Picture $picture,
+      bool $showText = true,
+      bool $search = false,
+      string $iconName = null
+    ): NavLinkedItem
+    {
+
         $itemAsIcon = static::asLink($link, $search);
-        $itemAsIcon->img = $img;
+
+        if ($iconName && array_key_exists($iconName, static::ICON_CLASSES)) {
+            $itemAsIcon->picture = static::setImage($picture, $iconName);
+        } else {
+            $itemAsIcon->picture = $picture;
+        }
+
         if (false === $showText) {
             $itemAsIcon->textClasses = 'visuallyhidden';
         }
 
         return $itemAsIcon;
+    }
+
+    private static function setImage(Picture $picture, $iconName)
+    {
+        $picture = FlexibleViewModel::fromViewModel($picture);
+
+        $fallback = $picture['fallback'];
+        $fallback['classes'] = static::ICON_CLASSES[$iconName];
+
+        return $picture->withProperty('fallback', $fallback);
     }
 
     public static function asLink(

--- a/src/ViewModel/Picture.php
+++ b/src/ViewModel/Picture.php
@@ -33,6 +33,11 @@ final class Picture implements ViewModel, IsImage
         $this->fallback = $fallback;
     }
 
+    public function getFallbackImage() : IsImage
+    {
+        return $this->fallback;
+    }
+
     public function getTemplateName() : string
     {
         return '/elife/patterns/templates/picture.mustache';

--- a/tests/src/ViewModel/IconNavLinkedItemTest.php
+++ b/tests/src/ViewModel/IconNavLinkedItemTest.php
@@ -25,6 +25,15 @@ final class IconNavLinkedItemTest extends ViewModelTest
     /**
      * @test
      */
+    public function classSetOnSearchIcon()
+    {
+        $linkNavLinkedItem = NavLinkedItem::asIcon(new Link('the text', 'the link path'), $this->img, true, true, 'search');
+        $this->assertSame('nav-primary__search_icon', $linkNavLinkedItem->picture->getFallbackImage()['classes']);
+    }
+
+    /**
+     * @test
+     */
     public function text_visible_if_flagged()
     {
         $linkNavLinkedItem = NavLinkedItem::asIcon(new Link('the text', 'the link path'), $this->img, true);


### PR DESCRIPTION
ping @thewilkybarkid 

This is a first attempt to programatically set the css classes as discussed. It has a few issues, and I'd appreciate some advice if you've got a moment to take a look.

**`NavLinkedItem`**
at the moment the `picture` property is public so I can write tests against its fallback image. Obviously we don't want a public property in there though! I'm unsure how best to expose it: bearing in mind it's populated by invocation of the static constructor `asIcon`, I'm not sure a regular accessor method would work. I was wondering about something like this?

```
public static function getPicture() : IsImage
{
    return static::asIcon->picture
}
```

**`IconNavLinkedItemTest`**
I'm having trouble writing the tests to prove the behaviour works. Line 39 results in an error `Call to undefined method eLife\Patterns\ViewModel\FlexibleViewModel::getFallbackImage()` (where `getFallbackImage` is an accessor method I've added to the `Picture` view model to enable interrogation of its fallback image). I'm not sure how to access a property of the original view model, once `FlexibleViewModel` has become involved.
