### PR TITLE
Allowing strapline to be null

### DIFF
--- a/src/ViewModel/ContentHeaderArticle.php
+++ b/src/ViewModel/ContentHeaderArticle.php
@@ -154,7 +154,7 @@ final class ContentHeaderArticle implements ViewModel
 
     public static function magazineWithBackground(
         string $title,
-        string $strapline,
+        string $strapline = null,
         AuthorList $authors,
         Picture $download = null,
         SubjectList $subjects = null,


### PR DESCRIPTION
`impactStatement` is passed to `magazine()` as the `$strapline` for a `correction` article. According to api-raml this field is optional for PoA articles, therefore here's a proposal to allow null for this field (which is already allows in the constructor.)