### PR TITLE
Assert viewer inline can't have additional assets with a heading

### DIFF
--- a/src/ViewModel/AssetViewerInline.php
+++ b/src/ViewModel/AssetViewerInline.php
@@ -37,7 +37,7 @@ final class AssetViewerInline implements ViewModel
         Assertion::nullOrMin($supplementOrdinal, 1);
         Assertion::nullOrNotBlank($parentId);
         Assertion::notBlank($label);
-        Assertion::allIsInstanceOf($additionalAssets, AdditionalAssets::class);
+        Assertion::allIsInstanceOf($additionalAssets, AdditionalAssetData::class);
 
         $this->id = $id;
         if ($supplementOrdinal) {
@@ -55,7 +55,11 @@ final class AssetViewerInline implements ViewModel
         $this->label = $label;
         $this->figuresPageFragLink = '#'.$id;
         $this->captionedAsset = $captionedAsset;
-        $this->additionalAssets = $additionalAssets;
+        if (!empty($additionalAssets)) {
+            $this->additionalAssets = [new AdditionalAssets(null, $additionalAssets)];
+        } else {
+            $this->additionalAssets = [];
+        }
     }
 
     public static function primary(

--- a/tests/src/ViewModel/AssetViewerInlineTest.php
+++ b/tests/src/ViewModel/AssetViewerInlineTest.php
@@ -36,7 +36,6 @@ final class AssetViewerInlineTest extends ViewModelTest
             ],
             'additionalAssets' => [
                 [
-                    'heading' => 'additional assets',
                     'data' => [
                         [
                             'assetId' => 'id',
@@ -60,11 +59,8 @@ final class AssetViewerInlineTest extends ViewModelTest
             CaptionedAsset::withOnlyHeading(new Image('/default/path',
                 [500 => '/path/to/image/500/wide', 250 => '/default/path']), 'heading'),
             [
-                new AdditionalAssets('additional assets',
-                    [
-                        AdditionalAssetData::withoutDoi('id', 'Without doi', DownloadLink::fromLink(new Link('Download link', 'http://google.com/download'),
-                            'File name'), 'part 2', 'http://google.com/', 'text'),
-                    ]),
+                AdditionalAssetData::withoutDoi('id', 'Without doi', DownloadLink::fromLink(new Link('Download link', 'http://google.com/download'),
+                    'File name'), 'part 2', 'http://google.com/', 'text'),
             ]);
 
         $this->assertSame($data['id'], $viewer['id']);
@@ -177,11 +173,8 @@ final class AssetViewerInlineTest extends ViewModelTest
                 AssetViewerInline::supplement('id', 1, 'parentId', 'label',
                     CaptionedAsset::withOnlyHeading(new Image('/default/path',
                         [500 => '/path/to/image/500/wide', 250 => '/default/path']), 'heading'), [
-                        new AdditionalAssets('additional assets',
-                            [
-                                AdditionalAssetData::withoutDoi('id', 'Without doi', DownloadLink::fromLink(new Link('Download link', 'http://google.com/download'),
-                                    'File name'), 'part 2', 'http://google.com/', 'text'),
-                            ]),
+                        AdditionalAssetData::withoutDoi('id', 'Without doi', DownloadLink::fromLink(new Link('Download link', 'http://google.com/download'),
+                            'File name'), 'part 2', 'http://google.com/', 'text'),
                     ]),
             ],
         ];


### PR DESCRIPTION
The asset viewer inline pattern doesn't quite reflect source data correctly, it can't have multiple sets with headings, only a simple list.