### PR TITLE
Trigger PR on journal when updated

### DIFF
--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -7,7 +7,9 @@ elifeLibrary {
         elifeLocalTests "dependencies=${dependencies} ./project_tests.sh", ["build/${dependencies}-phpunit.xml"]
     })
 
-    stage 'Downstream', {
-        build job: 'dependencies-journal-update-patterns-php', wait: false
+    elifeMainlineOnly {
+        stage 'Downstream', {
+            build job: 'dependencies-journal-update-patterns-php', wait: false
+        }
     }
 }


### PR DESCRIPTION
After the test pass, trigger a build of the dependency update pipeline. That pipeline will result in a PR on journal being opened.

Sample result: https://github.com/elifesciences/journal/pull/210