### PR TITLE
Updated pattern-library to 3327f7c: Allow italics in author affiliations

### DIFF
--- a/resources/templates/author-details.mustache
+++ b/resources/templates/author-details.mustache
@@ -6,7 +6,7 @@
   {{#hasAffiliations}}
   <ol class="author-details__affiliations author-details__section author-details__section--affiliations">
     {{#affiliations}}
-      <li class="author-details__affiliation">{{.}}</li>
+      <li class="author-details__affiliation">{{{.}}}</li>
     {{/affiliations}}
   </ol>
   {{/hasAffiliations}}

--- a/resources/templates/box.mustache
+++ b/resources/templates/box.mustache
@@ -4,7 +4,7 @@
     {{{label}}}
   {{/label}}
 
-  <h{{headingLevel}}>{{title}}</h{{headingLevel}}>
+  <h{{headingLevel}}>{{{title}}}</h{{headingLevel}}>
 
   {{#content}}
     {{{content}}}

--- a/resources/templates/content-header-article.mustache
+++ b/resources/templates/content-header-article.mustache
@@ -74,7 +74,7 @@
         <ol class="content-header__institution_list">
           {{#institutions.list}}
             <li class="content-header__institution_list_item">
-              <span class="content-header__institution">{{name}}</span>
+              <span class="content-header__institution">{{{name}}}</span>
             </li>
           {{/institutions.list}}
         </ol>


### PR DESCRIPTION
I have run http://ci--alfred.elifesciences.org/job/dependencies-patterns-php-update-pattern-library/69/ which resulted in this pull request.