### PR TITLE
Improve mixed_accessibility_text spacing

### DIFF
--- a/src/functions.php
+++ b/src/functions.php
@@ -58,17 +58,28 @@ function mixed_visibility_text(string $prefix, string $text, string $suffix = ''
 function mixed_accessibility_text(
     string $visibleInaccessiblePrefix,
     string $hiddenAccessibleText,
-    string $visibleInaccessibleSuffix = '') : string
-{
-    $wrappedVisibleInaccessibleTextPrefix = '';
-    $wrappedVisibleInaccessibleTextSuffix = '';
+    string $visibleInaccessibleSuffix = ''
+) : string {
+    $string = '';
 
     if (false === empty($visibleInaccessiblePrefix)) {
-        $wrappedVisibleInaccessibleTextPrefix = '<span aria-hidden="true">'.$visibleInaccessiblePrefix.' </span>';
-    }
-    if (false === empty($visibleInaccessibleSuffix)) {
-        $wrappedVisibleInaccessibleTextSuffix = '<span aria-hidden="true"> '.$visibleInaccessibleSuffix.'</span>';
+        $string .= '<span aria-hidden="true">'.$visibleInaccessiblePrefix.'</span><span class="visuallyhidden"> ';
+    } else {
+        $string .= '<span class="visuallyhidden">';
     }
 
-    return $wrappedVisibleInaccessibleTextPrefix.mixed_visibility_text($hiddenAccessibleText, $wrappedVisibleInaccessibleTextSuffix);
+    $string .= $hiddenAccessibleText;
+
+    if (false === empty($visibleInaccessibleSuffix)) {
+        if (false === empty($visibleInaccessiblePrefix)) {
+            $string .= '</span><span aria-hidden="true"> ';
+        } else {
+            $string .= ' </span><span aria-hidden="true">';
+        }
+        $string .= "{$visibleInaccessibleSuffix}</span>";
+    } else {
+        $string .= '</span>';
+    }
+
+    return $string;
 }

--- a/tests/src/FunctionsTest.php
+++ b/tests/src/FunctionsTest.php
@@ -120,12 +120,16 @@ final class FunctionsTest extends PHPUnit_Framework_TestCase
     {
         return [
             [
-                ['visible, inaccessible text', 'hidden, accessible text', ''],
-                '<span aria-hidden="true">visible, inaccessible text </span><span class="visuallyhidden">hidden, accessible text </span>',
+                ['visible, inaccessible prefix', 'hidden, accessible text', ''],
+                '<span aria-hidden="true">visible, inaccessible prefix</span><span class="visuallyhidden"> hidden, accessible text</span>',
             ],
             [
-                ['', 'hidden, accessible text', 'visible, inaccessible text'],
-                '<span class="visuallyhidden">hidden, accessible text </span><span aria-hidden="true"> visible, inaccessible text</span>',
+                ['', 'hidden, accessible text', 'visible, inaccessible suffix'],
+                '<span class="visuallyhidden">hidden, accessible text </span><span aria-hidden="true">visible, inaccessible suffix</span>',
+            ],
+            [
+                ['visible, inaccessible prefix', 'hidden, accessible text', 'visible, inaccessible suffix'],
+                '<span aria-hidden="true">visible, inaccessible prefix</span><span class="visuallyhidden"> hidden, accessible text</span><span aria-hidden="true"> visible, inaccessible suffix</span>',
             ],
         ];
     }

--- a/tests/src/ViewModel/HypothesisOpenerTest.php
+++ b/tests/src/ViewModel/HypothesisOpenerTest.php
@@ -13,7 +13,7 @@ final class HypothesisOpenerTest extends ViewModelTest
     {
         $data = [
             'button' => [
-                'text' => '<span aria-hidden="true"><span data-visible-annotation-count>&#8220;</span> </span><span class="visuallyhidden">Open annotations (there are currently <span data-hypothesis-annotation-count>0</span> annotations on this page). </span>',
+                'text' => '<span aria-hidden="true"><span data-visible-annotation-count>&#8220;</span></span><span class="visuallyhidden"> Open annotations (there are currently <span data-hypothesis-annotation-count>0</span> annotations on this page).</span>',
                 'type' => 'button',
             ],
         ];


### PR DESCRIPTION
Keeps the spaces inside `visuallyhidden`, unless there's both a prefix and a suffix.