### PR TITLE
Move PatternExtension from elife/journal to elife/patterns

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -34,6 +34,6 @@
         "twig/twig": "^2.0"
     },
     "suggest": {
-        "twig/twig": "Add support for rendering patterns using a Twig extension function."
+        "twig/twig": "^2.0, to use PatternExtension"
     }
 }

--- a/composer.json
+++ b/composer.json
@@ -19,7 +19,8 @@
     "require": {
         "php": "^7.0",
         "beberlei/assert": "^2.0",
-        "mustache/mustache": "^2.5"
+        "mustache/mustache": "^2.5",
+        "twig/twig": "^2.4"
     },
     "require-dev": {
         "cpliakas/git-wrapper": "^1.0",
@@ -31,8 +32,5 @@
         "symfony/finder": "^3.0",
         "symfony/process": "^3.0",
         "symfony/yaml": "^3.1"
-    },
-    "suggest": {
-        "twig/twig": "Add support for rendering patterns using a Twig extension function."
     }
 }

--- a/composer.json
+++ b/composer.json
@@ -31,5 +31,8 @@
         "symfony/finder": "^3.0",
         "symfony/process": "^3.0",
         "symfony/yaml": "^3.1"
+    },
+    "suggest": {
+        "twig/twig": "Add support for rendering patterns using a Twig extension function."
     }
 }

--- a/composer.json
+++ b/composer.json
@@ -19,8 +19,7 @@
     "require": {
         "php": "^7.0",
         "beberlei/assert": "^2.0",
-        "mustache/mustache": "^2.5",
-        "twig/twig": "^2.4"
+        "mustache/mustache": "^2.5"
     },
     "require-dev": {
         "cpliakas/git-wrapper": "^1.0",
@@ -31,6 +30,10 @@
         "symfony/filesystem": "^3.0",
         "symfony/finder": "^3.0",
         "symfony/process": "^3.0",
-        "symfony/yaml": "^3.1"
+        "symfony/yaml": "^3.1",
+        "twig/twig": "^2.0"
+    },
+    "suggest": {
+        "twig/twig": "Add support for rendering patterns using a Twig extension function."
     }
 }

--- a/src/Twig/PatternExtension.php
+++ b/src/Twig/PatternExtension.php
@@ -1,0 +1,34 @@
+<?php
+
+namespace eLife\Patterns\Twig;
+
+use eLife\Patterns\PatternRenderer;
+use eLife\Patterns\ViewModel;
+use Twig_Extension;
+use Twig_Function;
+
+final class PatternExtension extends Twig_Extension
+{
+    private $renderer;
+
+    public function __construct(PatternRenderer $renderer)
+    {
+        $this->renderer = $renderer;
+    }
+
+    public function getFunctions()
+    {
+        return [
+            new Twig_Function(
+                'render_pattern',
+                [$this, 'renderPattern'],
+                ['is_safe' => ['html']]
+            ),
+        ];
+    }
+
+    public function renderPattern(ViewModel $viewModel): string
+    {
+        return $this->renderer->render($viewModel);
+    }
+}

--- a/tests/src/Twig/PatternExtensionTest.php
+++ b/tests/src/Twig/PatternExtensionTest.php
@@ -6,12 +6,12 @@ use eLife\Patterns\PatternRenderer\CallbackPatternRenderer;
 use eLife\Patterns\Twig\PatternExtension;
 use eLife\Patterns\ViewModel;
 use eLife\Patterns\ViewModel\FlexibleViewModel;
-use PHPUnit\Framework\TestCase;
+use PHPUnit_Framework_TestCase;
 use Twig_Environment;
 use Twig_ExtensionInterface;
 use Twig_Loader_Array;
 
-final class PatternExtensionTest extends TestCase
+final class PatternExtensionTest extends PHPUnit_Framework_TestCase
 {
     /**
      * @test

--- a/tests/src/Twig/PatternExtensionTest.php
+++ b/tests/src/Twig/PatternExtensionTest.php
@@ -1,6 +1,6 @@
 <?php
 
-namespace test\eLife\Journal\Twig;
+namespace test\eLife\Patterns\Twig;
 
 use eLife\Patterns\PatternRenderer\CallbackPatternRenderer;
 use eLife\Patterns\Twig\PatternExtension;

--- a/tests/src/Twig/PatternExtensionTest.php
+++ b/tests/src/Twig/PatternExtensionTest.php
@@ -1,6 +1,6 @@
 <?php
 
-namespace test\eLife\Patterns\Twig;
+namespace tests\eLife\Patterns\Twig;
 
 use eLife\Patterns\PatternRenderer\CallbackPatternRenderer;
 use eLife\Patterns\Twig\PatternExtension;

--- a/tests/src/Twig/PatternExtensionTest.php
+++ b/tests/src/Twig/PatternExtensionTest.php
@@ -1,0 +1,42 @@
+<?php
+
+namespace test\eLife\Journal\Twig;
+
+use eLife\Patterns\PatternRenderer\CallbackPatternRenderer;
+use eLife\Patterns\Twig\PatternExtension;
+use eLife\Patterns\ViewModel;
+use eLife\Patterns\ViewModel\FlexibleViewModel;
+use PHPUnit\Framework\TestCase;
+use Twig_Environment;
+use Twig_ExtensionInterface;
+use Twig_Loader_Array;
+
+final class PatternExtensionTest extends TestCase
+{
+    /**
+     * @test
+     */
+    public function it_is_a_twig_extension()
+    {
+        $extension = new PatternExtension(new CallbackPatternRenderer(function (ViewModel $viewModel) : string {
+            return 'foobar';
+        }));
+
+        $this->assertInstanceOf(Twig_ExtensionInterface::class, $extension);
+    }
+
+    /**
+     * @test
+     * @depends it_is_a_twig_extension
+     */
+    public function it_renders_patterns()
+    {
+        $twigLoader = new Twig_Loader_Array(['foo' => '{{render_pattern(bar)}}']);
+        $twig = new Twig_Environment($twigLoader);
+        $twig->addExtension(new PatternExtension(new CallbackPatternRenderer(function (ViewModel $viewModel) : string {
+            return 'foobar';
+        })));
+
+        $this->assertSame('foobar', $twig->render('foo', ['bar' => new FlexibleViewModel('/foo', ['bar' => 'baz'])]));
+    }
+}


### PR DESCRIPTION
Per https://github.com/elifesciences/personalised-covers/pull/32, adds the `PatternExtension` implementation to the patterns package.

Adds the PatternExtension implementation, which provides the render_pattern
twig function, to the pattern library package so it can be reused outside of
journal.

Also adds a `suggests` section to composer that recommends Twig to render patterns since it's not a hard dependency of the package.