### PR TITLE
Correct downstream pipelines names to reflect their new folder

### DIFF
--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -11,8 +11,8 @@ elifeLibrary {
 
     elifeMainlineOnly {
         stage 'Downstream', {
-            build job: 'dependencies-journal-update-patterns-php', wait: false, parameters: [string(name: 'revision', value: commit)]
-            build job: 'dependencies-error-pages-update-patterns-php', wait: false, parameters: [string(name: 'revision', value: commit)]
+            build job: '/dependencies/dependencies-journal-update-patterns-php', wait: false, parameters: [string(name: 'revision', value: commit)]
+            build job: '/dependencies/dependencies-error-pages-update-patterns-php', wait: false, parameters: [string(name: 'revision', value: commit)]
         }
     }
 }


### PR DESCRIPTION
There are so many pipelines that I have to move them into the https://alfred.elifesciences.org/job/dependencies/ folder. However that changes their absolute path.