### PR TITLE
Updated pattern-library to 2d1d259: Hide metric charts from screen reader

### DIFF
--- a/resources/templates/bar-chart.mustache
+++ b/resources/templates/bar-chart.mustache
@@ -16,5 +16,6 @@
     data-chevron-right-svg="{{#assetRewrite}}{{assetsPath}}/img/patterns/molecules/chevron-right-ic.svg{{/assetRewrite}}"
     data-chevron-right-srcset="{{#assetRewrite}}{{assetsPath}}/img/patterns/molecules/chevron-right-ic_2x.png{{/assetRewrite}} 48w, {{#assetRewrite}}{{assetsPath}}/img/patterns/molecules/chevron-right-ic_1x.png{{/assetRewrite}} 24w"
     data-chevron-right-src="{{#assetRewrite}}{{assetsPath}}/img/patterns/molecules/chevron-right-ic_1x.png{{/assetRewrite}}"
+    aria-hidden="true"
 >
 </div>


### PR DESCRIPTION
I have run https://alfred.elifesciences.org/job/dependencies-patterns-php-update-pattern-library/436/ which resulted in this pull request.