### PR TITLE
Upgrade PHPUnit to version 6

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -24,7 +24,7 @@
     "require-dev": {
         "justinrainbow/json-schema": "^5.0",
         "php-jsonpointer/php-jsonpointer": "^1.0",
-        "phpunit/phpunit": "^5.2",
+        "phpunit/phpunit": "^6.0",
         "phpspec/prophecy": "^1.6",
         "symfony/filesystem": "^3.0",
         "symfony/finder": "^3.0",

--- a/phpunit.xml.dist
+++ b/phpunit.xml.dist
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="UTF-8"?>
 
 <phpunit xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
-         xsi:noNamespaceSchemaLocation="http://schema.phpunit.de/5.2/phpunit.xsd"
+         xsi:noNamespaceSchemaLocation="https://schema.phpunit.de/6.3/phpunit.xsd"
          backupGlobals="false" colors="true" bootstrap="vendor/autoload.php">
 
     <testsuites>

--- a/tests/src/FunctionsTest.php
+++ b/tests/src/FunctionsTest.php
@@ -4,9 +4,9 @@ namespace tests\eLife\Patterns;
 
 use function eLife\Patterns\mixed_accessibility_text;
 use function eLife\Patterns\mixed_visibility_text;
-use PHPUnit_Framework_TestCase;
+use PHPUnit\Framework\TestCase;
 
-final class FunctionsTest extends PHPUnit_Framework_TestCase
+final class FunctionsTest extends TestCase
 {
     /**
      * @test

--- a/tests/src/IntegrationTest.php
+++ b/tests/src/IntegrationTest.php
@@ -7,9 +7,9 @@ use eLife\Patterns\PatternRenderer\MustachePatternRenderer;
 use eLife\Patterns\ViewModel;
 use Mustache_Engine;
 use Mustache_Loader_FilesystemLoader;
-use PHPUnit_Framework_TestCase;
+use PHPUnit\Framework\TestCase;
 
-final class IntegrationTest extends PHPUnit_Framework_TestCase
+final class IntegrationTest extends TestCase
 {
     /**
      * @test

--- a/tests/src/PatternRenderer/CallbackPatternRendererTest.php
+++ b/tests/src/PatternRenderer/CallbackPatternRendererTest.php
@@ -5,9 +5,9 @@ namespace tests\eLife\Patterns\PatternRenderer;
 use eLife\Patterns\PatternRenderer;
 use eLife\Patterns\PatternRenderer\CallbackPatternRenderer;
 use eLife\Patterns\ViewModel;
-use PHPUnit_Framework_TestCase;
+use PHPUnit\Framework\TestCase;
 
-final class CallbackPatternRendererTest extends PHPUnit_Framework_TestCase
+final class CallbackPatternRendererTest extends TestCase
 {
     /**
      * @test

--- a/tests/src/PatternRenderer/MustachePatternRendererTest.php
+++ b/tests/src/PatternRenderer/MustachePatternRendererTest.php
@@ -6,9 +6,9 @@ use eLife\Patterns\PatternRenderer;
 use eLife\Patterns\PatternRenderer\MustachePatternRenderer;
 use eLife\Patterns\ViewModel;
 use Mustache_Engine;
-use PHPUnit_Framework_TestCase;
+use PHPUnit\Framework\TestCase;
 
-final class MustachePatternRendererTest extends PHPUnit_Framework_TestCase
+final class MustachePatternRendererTest extends TestCase
 {
     /**
      * @test

--- a/tests/src/Twig/PatternExtensionTest.php
+++ b/tests/src/Twig/PatternExtensionTest.php
@@ -6,12 +6,12 @@ use eLife\Patterns\PatternRenderer\CallbackPatternRenderer;
 use eLife\Patterns\Twig\PatternExtension;
 use eLife\Patterns\ViewModel;
 use eLife\Patterns\ViewModel\FlexibleViewModel;
-use PHPUnit_Framework_TestCase;
+use PHPUnit\Framework\TestCase;
 use Twig_Environment;
 use Twig_ExtensionInterface;
 use Twig_Loader_Array;
 
-final class PatternExtensionTest extends PHPUnit_Framework_TestCase
+final class PatternExtensionTest extends TestCase
 {
     /**
      * @test

--- a/tests/src/ViewModel/CaptionedAssetTest.php
+++ b/tests/src/ViewModel/CaptionedAssetTest.php
@@ -132,6 +132,7 @@ final class CaptionedAssetTest extends ViewModelTest
 
     public function test_it_works_with_latest_json()
     {
+        $this->markTestIncomplete();
     }
 
     public function viewModelProvider() : array

--- a/tests/src/ViewModel/ContentHeaderProfileLoggedInTest.php
+++ b/tests/src/ViewModel/ContentHeaderProfileLoggedInTest.php
@@ -110,7 +110,7 @@ final class ContentHeaderProfileLoggedInTest extends ViewModelTest
             new Link('log out link text', '/log-out-link-uri')
         );
 
-        $this->assertSameWithoutOrder(
+        $this->assertEquals(
             new Link('log out link text', '/log-out-link-uri'),
             $contentHeaderProfile['logoutLink']);
     }
@@ -129,7 +129,7 @@ final class ContentHeaderProfileLoggedInTest extends ViewModelTest
             ]
         );
 
-        $this->assertSameWithoutOrder(
+        $this->assertEquals(
             [
                 new Link('link 1 text', 'link 1 url'),
                 new Link('link 2 text', 'link 2 url'),

--- a/tests/src/ViewModel/FlexibleViewModelTest.php
+++ b/tests/src/ViewModel/FlexibleViewModelTest.php
@@ -5,9 +5,9 @@ namespace tests\eLife\Patterns\ViewModel;
 use eLife\Patterns\CastsToArray;
 use eLife\Patterns\ViewModel;
 use eLife\Patterns\ViewModel\FlexibleViewModel;
-use PHPUnit_Framework_TestCase;
+use PHPUnit\Framework\TestCase;
 
-final class FlexibleViewModelTest extends PHPUnit_Framework_TestCase
+final class FlexibleViewModelTest extends TestCase
 {
     /**
      * @test

--- a/tests/src/ViewModel/FormTest.php
+++ b/tests/src/ViewModel/FormTest.php
@@ -5,9 +5,9 @@ namespace tests\eLife\Patterns\ViewModel;
 use eLife\Patterns\CastsToArray;
 use eLife\Patterns\ViewModel\Form;
 use InvalidArgumentException;
-use PHPUnit_Framework_TestCase;
+use PHPUnit\Framework\TestCase;
 
-final class FormTest extends PHPUnit_Framework_TestCase
+final class FormTest extends TestCase
 {
     /**
      * @test

--- a/tests/src/ViewModel/ImageTest.php
+++ b/tests/src/ViewModel/ImageTest.php
@@ -5,9 +5,9 @@ namespace tests\eLife\Patterns\ViewModel;
 use eLife\Patterns\CastsToArray;
 use eLife\Patterns\ViewModel\Image;
 use InvalidArgumentException;
-use PHPUnit_Framework_TestCase;
+use PHPUnit\Framework\TestCase;
 
-final class ImageTest extends PHPUnit_Framework_TestCase
+final class ImageTest extends TestCase
 {
     /**
      * @test

--- a/tests/src/ViewModel/ImageTest.php
+++ b/tests/src/ViewModel/ImageTest.php
@@ -83,6 +83,7 @@ final class ImageTest extends TestCase
      */
     public function it_may_have_a_non_integer_srcset_key()
     {
-        new Image('/foo.png', ['1' => '/bar.png', '1.5' => '/baz.png']);
+        $image = new Image('/foo.png', $srcset = ['1' => '/bar.png', '1.5' => '/baz.png']);
+        $this->assertSame('/bar.png 1x, /baz.png 1.5x', $image['srcset']);
     }
 }

--- a/tests/src/ViewModel/InputTest.php
+++ b/tests/src/ViewModel/InputTest.php
@@ -5,9 +5,9 @@ namespace tests\eLife\Patterns\ViewModel;
 use eLife\Patterns\CastsToArray;
 use eLife\Patterns\ViewModel\Input;
 use InvalidArgumentException;
-use PHPUnit_Framework_TestCase;
+use PHPUnit\Framework\TestCase;
 
-final class InputTest extends PHPUnit_Framework_TestCase
+final class InputTest extends TestCase
 {
     /**
      * @test

--- a/tests/src/ViewModel/LinkTest.php
+++ b/tests/src/ViewModel/LinkTest.php
@@ -5,9 +5,9 @@ namespace tests\eLife\Patterns\ViewModel;
 use eLife\Patterns\CastsToArray;
 use eLife\Patterns\ViewModel\Link;
 use InvalidArgumentException;
-use PHPUnit_Framework_TestCase;
+use PHPUnit\Framework\TestCase;
 
-final class LinkTest extends PHPUnit_Framework_TestCase
+final class LinkTest extends TestCase
 {
     /**
      * @test

--- a/tests/src/ViewModel/MediaSourceTest.php
+++ b/tests/src/ViewModel/MediaSourceTest.php
@@ -30,7 +30,7 @@ final class MediaSourceTest extends ViewModelTest
             new MediaSourceFallback($data['fallback']['content'], $data['fallback']['isExternal'])
         );
 
-        $this->assertSameValuesWithoutOrder($mediaSource, $data);
+        $this->assertSameValuesWithoutOrder($mediaSource->toArray(), $data);
     }
 
     public function viewModelProvider() : array

--- a/tests/src/ViewModel/MediaTypeTest.php
+++ b/tests/src/ViewModel/MediaTypeTest.php
@@ -5,10 +5,10 @@ namespace tests\eLife\Patterns\ViewModel;
 use eLife\Patterns\CastsToArray;
 use eLife\Patterns\ViewModel\MediaType;
 use InvalidArgumentException;
-use PHPUnit_Framework_TestCase;
+use PHPUnit\Framework\TestCase;
 use Traversable;
 
-final class MediaTypeTest extends PHPUnit_Framework_TestCase
+final class MediaTypeTest extends TestCase
 {
     /**
      * @test

--- a/tests/src/ViewModel/MessageGroupTest.php
+++ b/tests/src/ViewModel/MessageGroupTest.php
@@ -5,9 +5,9 @@ namespace tests\eLife\Patterns\ViewModel;
 use eLife\Patterns\CastsToArray;
 use eLife\Patterns\ViewModel\MessageGroup;
 use InvalidArgumentException;
-use PHPUnit_Framework_TestCase;
+use PHPUnit\Framework\TestCase;
 
-final class MessageGroupTest extends PHPUnit_Framework_TestCase
+final class MessageGroupTest extends TestCase
 {
     /**
      * @test

--- a/tests/src/ViewModel/ReferenceAuthorListTest.php
+++ b/tests/src/ViewModel/ReferenceAuthorListTest.php
@@ -6,9 +6,9 @@ use eLife\Patterns\CastsToArray;
 use eLife\Patterns\ViewModel\Author;
 use eLife\Patterns\ViewModel\ReferenceAuthorList;
 use InvalidArgumentException;
-use PHPUnit_Framework_TestCase;
+use PHPUnit\Framework\TestCase;
 
-final class ReferenceAuthorListTest extends PHPUnit_Framework_TestCase
+final class ReferenceAuthorListTest extends TestCase
 {
     /**
      * @test

--- a/tests/src/ViewModel/SubjectFilterTest.php
+++ b/tests/src/ViewModel/SubjectFilterTest.php
@@ -5,9 +5,9 @@ namespace tests\eLife\Patterns\ViewModel;
 use eLife\Patterns\CastsToArray;
 use eLife\Patterns\ViewModel\SubjectFilter;
 use InvalidArgumentException;
-use PHPUnit_Framework_TestCase;
+use PHPUnit\Framework\TestCase;
 
-final class SubjectFilterTest extends PHPUnit_Framework_TestCase
+final class SubjectFilterTest extends TestCase
 {
     /**
      * @test

--- a/tests/src/ViewModel/ViewModelTest.php
+++ b/tests/src/ViewModel/ViewModelTest.php
@@ -5,11 +5,11 @@ namespace tests\eLife\Patterns\ViewModel;
 use eLife\Patterns\CastsToArray;
 use eLife\Patterns\ViewModel;
 use JsonSchema\Validator;
-use PHPUnit_Framework_TestCase;
+use PHPUnit\Framework\TestCase;
 use stdClass;
 use Symfony\Component\Yaml\Yaml;
 
-abstract class ViewModelTest extends PHPUnit_Framework_TestCase
+abstract class ViewModelTest extends TestCase
 {
     /**
      * @test

--- a/tests/src/ViewModel/ViewModelTest.php
+++ b/tests/src/ViewModel/ViewModelTest.php
@@ -54,10 +54,14 @@ abstract class ViewModelTest extends TestCase
         $viewModel = $this->createViewModel();
         $data = $viewModel->toArray();
 
-        foreach ($data as $key => $value) {
-            $actual = $this->handleValue($viewModel[$key]);
+        if ($data) {
+            foreach ($data as $key => $value) {
+                $actual = $this->handleValue($viewModel[$key]);
 
-            $this->assertSame($value, $actual);
+                $this->assertSame($value, $actual);
+            }
+        } else {
+            $this->assertSame([], $data);
         }
     }
 


### PR DESCRIPTION
Best we can do while staying on PHP 7.0

Doesn't really solve the [`phpunit-mock-objects`](https://packagist.org/packages/phpunit/phpunit-mock-objects) warning, but it's a step in that direction.