### PR TITLE
Updated pattern-library to d638d1a: fix: side-by-side menu option no longer appearing on articles

### DIFF
--- a/resources/templates/view-selector.mustache
+++ b/resources/templates/view-selector.mustache
@@ -15,7 +15,7 @@
       </li>
     {{/otherLinks}}
 
-    <li class="view-selector__divider"></li>
+    <li class="view-selector__list-item view-selector__divider"></li>
 
     {{#jumpLinks}}
       {{#links}}


### PR DESCRIPTION
I have run https://alfred.elifesciences.org/job/dependencies-patterns-php-update-pattern-library/523/ which resulted in this pull request.