### PR TITLE
Do not centre button collection by default.

### DIFF
--- a/src/ViewModel/PersonalisedCoverDownload.php
+++ b/src/ViewModel/PersonalisedCoverDownload.php
@@ -24,16 +24,6 @@ final class PersonalisedCoverDownload implements ViewModel
         Assertion::notEmpty($text);
         Assertion::allIsInstanceOf($text, Paragraph::class);
 
-        if (!$a4ButtonCollection['centered']) {
-            $a4ButtonCollection = FlexibleViewModel::fromViewModel($a4ButtonCollection)
-                ->withProperty('centered', true);
-        }
-
-        if (!$letterButtonCollection['centered']) {
-            $letterButtonCollection = FlexibleViewModel::fromViewModel($letterButtonCollection)
-                ->withProperty('centered', true);
-        }
-
         $a4ButtonCollection = FlexibleViewModel::fromViewModel($a4ButtonCollection)
             ->withProperty('classes', 'button-collection--a4');
 

--- a/tests/src/ViewModel/PersonalisedCoverDownloadTest.php
+++ b/tests/src/ViewModel/PersonalisedCoverDownloadTest.php
@@ -42,7 +42,6 @@ final class PersonalisedCoverDownloadTest extends ViewModelTest
                         'text' => 'text',
                     ],
                 ],
-                'centered' => true,
                 'classes' => 'button-collection--a4',
             ],
             'letterListHeading' => [
@@ -57,7 +56,6 @@ final class PersonalisedCoverDownloadTest extends ViewModelTest
                         'text' => 'text',
                     ],
                 ],
-                'centered' => true,
                 'classes' => 'button-collection--letter',
             ],
         ];


### PR DESCRIPTION
Re issue https://github.com/elifesciences/issues/issues/6167

In patterns library, these buttons are not centred, so here in the personalised covers ViewModel do not override them to always be centred.