### PR TITLE
Change h1 in personalised cover download template.

### DIFF
--- a/resources/templates/personalised-cover-download.mustache
+++ b/resources/templates/personalised-cover-download.mustache
@@ -17,7 +17,7 @@
       </a>
     </div>
   </header>
-  <h1 class="personalised-cover__header-text">Download your personalised magazine cover</h1>
+  <h1 class="personalised-cover__header-text">Download your personalised eLife cover</h1>
   <div class="personalised-cover-outer">
     <div class="personalised-cover-text">
       {{#text}}


### PR DESCRIPTION
Re issue https://github.com/elifesciences/issues/issues/6193

A small change to the text in the `<h1>` tag on personalised cover download landing page.