### PR TITLE
Pass homePagePath to covers view model.

### DIFF
--- a/src/ViewModel/PersonalisedCoverDownload.php
+++ b/src/ViewModel/PersonalisedCoverDownload.php
@@ -12,6 +12,7 @@ final class PersonalisedCoverDownload implements ViewModel
     use ArrayAccessFromProperties;
     use ArrayFromProperties;
 
+    private $homePagePath;
     private $title;
     private $text;
     private $picture;
@@ -20,8 +21,9 @@ final class PersonalisedCoverDownload implements ViewModel
     private $letterListHeading;
     private $letterButtonCollection;
 
-    public function __construct(string $title, array $text, Picture $picture, ListHeading $a4ListHeading, ButtonCollection $a4ButtonCollection, ListHeading $letterListHeading, ButtonCollection $letterButtonCollection)
+    public function __construct(string $homePagePath, string $title, array $text, Picture $picture, ListHeading $a4ListHeading, ButtonCollection $a4ButtonCollection, ListHeading $letterListHeading, ButtonCollection $letterButtonCollection)
     {
+        Assertion::notBlank($homePagePath);
         Assertion::notEmpty($text);
         Assertion::allIsInstanceOf($text, Paragraph::class);
 
@@ -31,6 +33,7 @@ final class PersonalisedCoverDownload implements ViewModel
         $letterButtonCollection = FlexibleViewModel::fromViewModel($letterButtonCollection)
             ->withProperty('classes', 'button-collection--letter');
 
+        $this->homePagePath = $homePagePath;
         $this->title = $title;
         $this->text = $text;
         $this->picture = $picture;

--- a/tests/src/ViewModel/PersonalisedCoverDownloadTest.php
+++ b/tests/src/ViewModel/PersonalisedCoverDownloadTest.php
@@ -19,6 +19,7 @@ final class PersonalisedCoverDownloadTest extends ViewModelTest
     public function it_has_data()
     {
         $data = [
+            'homePagePath' => 'https://example.org',
             'title' => 'title',
             'text' => [
                 [
@@ -62,6 +63,7 @@ final class PersonalisedCoverDownloadTest extends ViewModelTest
         ];
 
         $download = new PersonalisedCoverDownload(
+            $data['homePagePath'],
             $data['title'],
             array_map(function (array $paragraph) {
                 return new Paragraph($paragraph['text']);
@@ -73,6 +75,7 @@ final class PersonalisedCoverDownloadTest extends ViewModelTest
             new ButtonCollection([Button::link($data['letterButtonCollection']['buttons'][0]['text'], $data['letterButtonCollection']['buttons'][0]['path'])])
         );
 
+        $this->assertSame($data['homePagePath'], $download['homePagePath']);
         $this->assertSame($data['title'], $download['title']);
         $this->assertSameWithoutOrder($data['text'], $download['text']);
         $this->assertSame($data['a4ListHeading'], $download['a4ListHeading']->toArray());
@@ -89,7 +92,7 @@ final class PersonalisedCoverDownloadTest extends ViewModelTest
     {
         $this->expectException(InvalidArgumentException::class);
 
-        new PersonalisedCoverDownload('title', [], new Picture([], new Image('path')), new ListHeading('heading'), new ButtonCollection([Button::link('text', 'path')]), new ListHeading('heading'), new ButtonCollection([Button::link('text', 'path')]));
+        new PersonalisedCoverDownload('/home/page/path', 'title', [], new Picture([], new Image('path')), new ListHeading('heading'), new ButtonCollection([Button::link('text', 'path')]), new ListHeading('heading'), new ButtonCollection([Button::link('text', 'path')]));
     }
 
     /**
@@ -99,13 +102,13 @@ final class PersonalisedCoverDownloadTest extends ViewModelTest
     {
         $this->expectException(InvalidArgumentException::class);
 
-        new PersonalisedCoverDownload('title', ['foo'], new Picture([], new Image('path')), new ListHeading('heading'), new ButtonCollection([Button::link('text', 'path')]), new ListHeading('heading'), new ButtonCollection([Button::link('text', 'path')]));
+        new PersonalisedCoverDownload('/home/page/path', 'title', ['foo'], new Picture([], new Image('path')), new ListHeading('heading'), new ButtonCollection([Button::link('text', 'path')]), new ListHeading('heading'), new ButtonCollection([Button::link('text', 'path')]));
     }
 
     public function viewModelProvider() : array
     {
         return [
-            [new PersonalisedCoverDownload('title', [new Paragraph('foo')], new Picture([], new Image('path')), new ListHeading('heading'), new ButtonCollection([Button::link('text', 'path')]), new ListHeading('heading'), new ButtonCollection([Button::link('text', 'path')]))],
+            [new PersonalisedCoverDownload('/home/page/path', 'title', [new Paragraph('foo')], new Picture([], new Image('path')), new ListHeading('heading'), new ButtonCollection([Button::link('text', 'path')]), new ListHeading('heading'), new ButtonCollection([Button::link('text', 'path')]))],
         ];
     }
 


### PR DESCRIPTION
Re issue https://github.com/elifesciences/issues/issues/6196

In discussion today with Joel, the most expendient solution for this seemed to be for me to prepare a PR with a potential solution to pass a URL for the eLife logo link in the personalised covers view model, and have @nlisgo review it, if you would please when time allows.

The `<a href="{{homePagePath}}">` line is already present in https://github.com/elifesciences/patterns-php/blob/master/resources/templates/personalised-cover-download.mustache and we're not populating the value.

Other examples I can find of `homePagePath` are indicating it would be a relative path, for example from a journal page to the journal home page can be a relative path / link. In one test case I used an absolute URL for the value which seems to function fine.

I tested the ViewModel file in my locally run personalised-covers project, and it results in the logo linking to `https://elifesciences.org/`, the value I passed in, so I'm confident this will solve the problem.

@nlisgo, what do you think of the changes included in this PR? Should we continue to use the `homePagePath` variable name for this, or maybe because we expect personalised covers to always specify an absolute URL for the value, should we rename the variable to be more clear of its purpose?