### PR TITLE
Updated pattern-library to 88ac499: Allow site-header-title to have simpler variants

### DIFF
--- a/resources/definitions/personalised-cover-download.yaml
+++ b/resources/definitions/personalised-cover-download.yaml
@@ -1,10 +1,14 @@
 $schema: 'http://json-schema.org/draft-04/schema#'
 type: object
 properties:
-    logo:
+    siteHeaderTitle:
         $schema: 'http://json-schema.org/draft-04/schema#'
         type: object
         properties:
+            borderVariant:
+                type: boolean
+            isWrapped:
+                type: boolean
             homePagePath:
                 type: string
                 minLength: 1
@@ -202,7 +206,6 @@ properties:
         required:
             - buttons
 required:
-    - logo
     - title
     - text
     - picture

--- a/resources/definitions/site-header-title.yaml
+++ b/resources/definitions/site-header-title.yaml
@@ -1,6 +1,10 @@
 $schema: 'http://json-schema.org/draft-04/schema#'
 type: object
 properties:
+    borderVariant:
+        type: boolean
+    isWrapped:
+        type: boolean
     homePagePath:
         type: string
         minLength: 1

--- a/resources/definitions/site-header.yaml
+++ b/resources/definitions/site-header.yaml
@@ -1,10 +1,14 @@
 $schema: 'http://json-schema.org/draft-04/schema#'
 type: object
 properties:
-    logo:
+    title:
         $schema: 'http://json-schema.org/draft-04/schema#'
         type: object
         properties:
+            borderVariant:
+                type: boolean
+            isWrapped:
+                type: boolean
             homePagePath:
                 type: string
                 minLength: 1
@@ -715,6 +719,6 @@ properties:
         required:
             - compactForm
 required:
-    - logo
+    - title
     - primaryLinks
     - secondaryLinks

--- a/resources/templates/personalised-cover-download.mustache
+++ b/resources/templates/personalised-cover-download.mustache
@@ -1,14 +1,7 @@
 <div class="wrapper-alternative">
-  <header class="site-header clearfix" data-behaviour="SiteHeader" id="siteHeader">
-    <div class="site-header__title-border" role="banner">
-      <div class="site-header__skip_to_content">
-        <a href="#maincontent" class="site-header__skip_to_content__link button button--default">Skip to Content</a>
-      </div>
-      {{#logo}}
-        {{> resources/templates/site-header-logo }}
-      {{/logo}}
-    </div>
-  </header>
+  {{#siteHeaderTitle}}
+    {{> resources/templates/site-header-title }}
+  {{/siteHeaderTitle}}
   <h1 class="personalised-cover__header-text">{{{title}}}</h1>
   <div class="personalised-cover-outer">
     <div class="personalised-cover-text">

--- a/resources/templates/site-header-logo.mustache
+++ b/resources/templates/site-header-logo.mustache
@@ -1,9 +1,0 @@
-<a href="{{homePagePath}}" class="site-header__logo_link">
-  <picture class="site-header__logo_link_image">
-    {{! 45.625em is 730px, which is $bkpt-site--medium }}
-    <source srcset="{{#assetRewrite}}{{assetsPath}}/img/patterns/organisms/elife-logo-xs.svg{{/assetRewrite}}" type="image/svg+xml" media="(min-width: 45.625em)">
-    <source srcset="{{#assetRewrite}}{{assetsPath}}/img/patterns/organisms/elife-logo-symbol.svg{{/assetRewrite}}" type="image/svg+xml">
-    <img src="{{#assetRewrite}}{{assetsPath}}/img/patterns/organisms/elife-logo-xs@1x.png{{/assetRewrite}}" alt="eLife logo" class="site-header__logo_link"/>
-  </picture>
-  <span class="visuallyhidden" >eLife home page</span>
-</a>

--- a/resources/templates/site-header-title.mustache
+++ b/resources/templates/site-header-title.mustache
@@ -1,0 +1,20 @@
+{{#isWrapped}}
+  <header class="site-header clearfix" id="siteHeader">
+{{/isWrapped}}
+  <div class="site-header__title{{#borderVariant}}-border{{/borderVariant}} clearfix" role="banner">
+    <div class="site-header__skip_to_content">
+      <a href="#maincontent" class="site-header__skip_to_content__link button button--default">Skip to Content</a>
+    </div>
+    <a href="{{homePagePath}}" class="site-header__logo_link">
+      <picture class="site-header__logo_link_image">
+        {{! 45.625em is 730px, which is $bkpt-site--medium }}
+        <source srcset="{{#assetRewrite}}{{assetsPath}}/img/patterns/organisms/elife-logo-xs.svg{{/assetRewrite}}" type="image/svg+xml" media="(min-width: 45.625em)">
+        <source srcset="{{#assetRewrite}}{{assetsPath}}/img/patterns/organisms/elife-logo-symbol.svg{{/assetRewrite}}" type="image/svg+xml">
+        <img src="{{#assetRewrite}}{{assetsPath}}/img/patterns/organisms/elife-logo-xs@1x.png{{/assetRewrite}}" alt="eLife logo" class="site-header__logo_link"/>
+      </picture>
+      <span class="visuallyhidden" >eLife home page</span>
+    </a>
+  </div>
+{{#isWrapped}}
+  </header>
+{{/isWrapped}}

--- a/resources/templates/site-header.mustache
+++ b/resources/templates/site-header.mustache
@@ -1,12 +1,7 @@
 <header class="site-header clearfix" data-behaviour="SiteHeader" id="siteHeader">
-  <div class="site-header__title clearfix" role="banner">
-    <div class="site-header__skip_to_content">
-      <a href="#maincontent" class="site-header__skip_to_content__link button button--default">Skip to Content</a>
-    </div>
-    {{#logo}}
-      {{> resources/templates/site-header-logo }}
-    {{/logo}}
-  </div>
+  {{#title}}
+    {{> resources/templates/site-header-title }}
+  {{/title}}
   <div class="site-header__navigation" role="navigation" aria-label="Main navigation">
 
     {{#secondaryLinks}}

--- a/src/ViewModel/PersonalisedCoverDownload.php
+++ b/src/ViewModel/PersonalisedCoverDownload.php
@@ -12,7 +12,7 @@ final class PersonalisedCoverDownload implements ViewModel
     use ArrayAccessFromProperties;
     use ArrayFromProperties;
 
-    private $logo;
+    private $siteHeaderTitle;
     private $title;
     private $text;
     private $picture;
@@ -21,7 +21,7 @@ final class PersonalisedCoverDownload implements ViewModel
     private $letterListHeading;
     private $letterButtonCollection;
 
-    public function __construct(SiteHeaderLogo $logo, string $title, array $text, Picture $picture, ListHeading $a4ListHeading, ButtonCollection $a4ButtonCollection, ListHeading $letterListHeading, ButtonCollection $letterButtonCollection)
+    public function __construct(SiteHeaderTitle $siteHeaderTitle, string $title, array $text, Picture $picture, ListHeading $a4ListHeading, ButtonCollection $a4ButtonCollection, ListHeading $letterListHeading, ButtonCollection $letterButtonCollection)
     {
         Assertion::notEmpty($text);
         Assertion::allIsInstanceOf($text, Paragraph::class);
@@ -32,7 +32,7 @@ final class PersonalisedCoverDownload implements ViewModel
         $letterButtonCollection = FlexibleViewModel::fromViewModel($letterButtonCollection)
             ->withProperty('classes', 'button-collection--letter');
 
-        $this->logo = $logo;
+        $this->siteHeaderTitle = $siteHeaderTitle;
         $this->title = $title;
         $this->text = $text;
         $this->picture = $picture;

--- a/src/ViewModel/SiteHeader.php
+++ b/src/ViewModel/SiteHeader.php
@@ -12,14 +12,14 @@ final class SiteHeader implements ViewModel
     use ArrayAccessFromProperties;
     use ArrayFromProperties;
 
-    private $logo;
+    private $title;
     private $primaryLinks;
     private $secondaryLinks;
     private $searchBox;
 
-    public function __construct(SiteHeaderLogo $logo, SiteHeaderNavBar $primaryLinks, SiteHeaderNavBar $secondaryLinks, SearchBox $searchBox = null)
+    public function __construct(SiteHeaderTitle $title, SiteHeaderNavBar $primaryLinks, SiteHeaderNavBar $secondaryLinks, SearchBox $searchBox = null)
     {
-        $this->logo = $logo;
+        $this->title = $title;
         $this->primaryLinks = $primaryLinks;
         $this->secondaryLinks = $secondaryLinks;
         if ($searchBox) {

--- a/src/ViewModel/SiteHeaderTitle.php
+++ b/src/ViewModel/SiteHeaderTitle.php
@@ -7,22 +7,26 @@ use eLife\Patterns\ArrayAccessFromProperties;
 use eLife\Patterns\ArrayFromProperties;
 use eLife\Patterns\ViewModel;
 
-final class SiteHeaderLogo implements ViewModel
+final class SiteHeaderTitle implements ViewModel
 {
     use ArrayAccessFromProperties;
     use ArrayFromProperties;
 
     private $homePagePath;
+    private $isWrapped;
+    private $borderVariant;
 
-    public function __construct(string $homePagePath)
+    public function __construct(string $homePagePath, bool $isWrapped = false, bool $borderVariant = false)
     {
         Assertion::notBlank($homePagePath);
 
         $this->homePagePath = $homePagePath;
+        $this->isWrapped = $isWrapped;
+        $this->borderVariant = $borderVariant;
     }
 
     public function getTemplateName() : string
     {
-        return 'resources/templates/site-header-logo.mustache';
+        return 'resources/templates/site-header-title.mustache';
     }
 }

--- a/tests/src/ViewModel/PersonalisedCoverDownloadTest.php
+++ b/tests/src/ViewModel/PersonalisedCoverDownloadTest.php
@@ -9,7 +9,7 @@ use eLife\Patterns\ViewModel\ListHeading;
 use eLife\Patterns\ViewModel\Paragraph;
 use eLife\Patterns\ViewModel\PersonalisedCoverDownload;
 use eLife\Patterns\ViewModel\Picture;
-use eLife\Patterns\ViewModel\SiteHeaderLogo;
+use eLife\Patterns\ViewModel\SiteHeaderTitle;
 use InvalidArgumentException;
 
 final class PersonalisedCoverDownloadTest extends ViewModelTest
@@ -20,8 +20,10 @@ final class PersonalisedCoverDownloadTest extends ViewModelTest
     public function it_has_data()
     {
         $data = [
-            'logo' => [
+            'siteHeaderTitle' => [
                 'homePagePath' => 'https://example.org',
+                'isWrapped' => true,
+                'borderVariant' => true,
             ],
             'title' => 'title',
             'text' => [
@@ -66,7 +68,7 @@ final class PersonalisedCoverDownloadTest extends ViewModelTest
         ];
 
         $download = new PersonalisedCoverDownload(
-            new SiteHeaderLogo($data['logo']['homePagePath']),
+            new SiteHeaderTitle($data['siteHeaderTitle']['homePagePath'], $data['siteHeaderTitle']['isWrapped'], $data['siteHeaderTitle']['borderVariant']),
             $data['title'],
             array_map(function (array $paragraph) {
                 return new Paragraph($paragraph['text']);
@@ -78,7 +80,7 @@ final class PersonalisedCoverDownloadTest extends ViewModelTest
             new ButtonCollection([Button::link($data['letterButtonCollection']['buttons'][0]['text'], $data['letterButtonCollection']['buttons'][0]['path'])])
         );
 
-        $this->assertSame($data['logo'], $download['logo']->toArray());
+        $this->assertSame($data['siteHeaderTitle'], $download['siteHeaderTitle']->toArray());
         $this->assertSame($data['title'], $download['title']);
         $this->assertSameWithoutOrder($data['text'], $download['text']);
         $this->assertSame($data['a4ListHeading'], $download['a4ListHeading']->toArray());
@@ -95,7 +97,7 @@ final class PersonalisedCoverDownloadTest extends ViewModelTest
     {
         $this->expectException(InvalidArgumentException::class);
 
-        new PersonalisedCoverDownload(new SiteHeaderLogo('/home/page/path'), 'title', [], new Picture([], new Image('path')), new ListHeading('heading'), new ButtonCollection([Button::link('text', 'path')]), new ListHeading('heading'), new ButtonCollection([Button::link('text', 'path')]));
+        new PersonalisedCoverDownload(new SiteHeaderTitle('/home/page/path', true, true), 'title', [], new Picture([], new Image('path')), new ListHeading('heading'), new ButtonCollection([Button::link('text', 'path')]), new ListHeading('heading'), new ButtonCollection([Button::link('text', 'path')]));
     }
 
     /**
@@ -105,13 +107,13 @@ final class PersonalisedCoverDownloadTest extends ViewModelTest
     {
         $this->expectException(InvalidArgumentException::class);
 
-        new PersonalisedCoverDownload(new SiteHeaderLogo('/home/page/path'), 'title', ['foo'], new Picture([], new Image('path')), new ListHeading('heading'), new ButtonCollection([Button::link('text', 'path')]), new ListHeading('heading'), new ButtonCollection([Button::link('text', 'path')]));
+        new PersonalisedCoverDownload(new SiteHeaderTitle('/home/page/path', true, true), 'title', ['foo'], new Picture([], new Image('path')), new ListHeading('heading'), new ButtonCollection([Button::link('text', 'path')]), new ListHeading('heading'), new ButtonCollection([Button::link('text', 'path')]));
     }
 
     public function viewModelProvider() : array
     {
         return [
-            [new PersonalisedCoverDownload(new SiteHeaderLogo('/home/page/path'), 'title', [new Paragraph('foo')], new Picture([], new Image('path')), new ListHeading('heading'), new ButtonCollection([Button::link('text', 'path')]), new ListHeading('heading'), new ButtonCollection([Button::link('text', 'path')]))],
+            [new PersonalisedCoverDownload(new SiteHeaderTitle('/home/page/path', true, true), 'title', [new Paragraph('foo')], new Picture([], new Image('path')), new ListHeading('heading'), new ButtonCollection([Button::link('text', 'path')]), new ListHeading('heading'), new ButtonCollection([Button::link('text', 'path')]))],
         ];
     }
 

--- a/tests/src/ViewModel/SiteHeaderTest.php
+++ b/tests/src/ViewModel/SiteHeaderTest.php
@@ -13,7 +13,7 @@ use eLife\Patterns\ViewModel\NavLinkedItem;
 use eLife\Patterns\ViewModel\Picture;
 use eLife\Patterns\ViewModel\SearchBox;
 use eLife\Patterns\ViewModel\SiteHeader;
-use eLife\Patterns\ViewModel\SiteHeaderLogo;
+use eLife\Patterns\ViewModel\SiteHeaderTitle;
 use eLife\Patterns\ViewModel\SiteHeaderNavBar;
 use InvalidArgumentException;
 use TypeError;
@@ -21,7 +21,7 @@ use TypeError;
 final class SiteHeaderTest extends ViewModelTest
 {
     private $img;
-    private $logo;
+    private $title;
     private $primaryLinks;
     private $secondaryLinks;
     private $searchBox;
@@ -35,7 +35,7 @@ final class SiteHeaderTest extends ViewModelTest
             ],
             new Image('/path/to/fallback/', ['2' => '/hi-res/image/path/in/srcset', '1' => '/image/path/in/srcset'], 'alt text')
         );
-        $this->logo = new SiteHeaderLogo('/home/page/path');
+        $this->title = new SiteHeaderTitle('/home/page/path');
         $this->primaryLinks = SiteHeaderNavBar::primary(
             [
                 NavLinkedItem::asIcon(new Link('text-first', '/path/first'), $this->img),
@@ -66,8 +66,8 @@ final class SiteHeaderTest extends ViewModelTest
      */
     public function it_has_data()
     {
-        $siteHeader = new SiteHeader($this->logo, $this->primaryLinks, $this->secondaryLinks, $this->searchBox);
-        $this->assertSame($this->logo, $siteHeader['logo']);
+        $siteHeader = new SiteHeader($this->title, $this->primaryLinks, $this->secondaryLinks, $this->searchBox);
+        $this->assertSame($this->title, $siteHeader['title']);
         $this->assertSame($this->primaryLinks, $siteHeader['primaryLinks']);
         $this->assertSame($this->secondaryLinks, $siteHeader['secondaryLinks']);
         $this->assertSameValuesWithoutOrder($this->searchBox, $siteHeader['searchBox']);
@@ -103,7 +103,7 @@ final class SiteHeaderTest extends ViewModelTest
 
     public function viewModelProvider() : array
     {
-        $logo = new SiteHeaderLogo('/home/page/path');
+        $title = new SiteHeaderTitle('/home/page/path');
 
         $img = new Picture(
             [
@@ -130,8 +130,8 @@ final class SiteHeaderTest extends ViewModelTest
         );
 
         return [
-            'minimum' => [new SiteHeader($logo, $primaryLinks, $secondaryLinks)],
-            'complete' => [new SiteHeader($logo, $primaryLinks, $secondaryLinks, $this->searchBox)],
+            'minimum' => [new SiteHeader($title, $primaryLinks, $secondaryLinks)],
+            'complete' => [new SiteHeader($title, $primaryLinks, $secondaryLinks, $this->searchBox)],
         ];
     }
 

--- a/tests/src/ViewModel/SiteHeaderTest.php
+++ b/tests/src/ViewModel/SiteHeaderTest.php
@@ -89,7 +89,7 @@ final class SiteHeaderTest extends ViewModelTest
     public function primary_links_must_be_supplied()
     {
         $this->expectException(TypeError::class);
-        new SiteHeader($this->logo, null, $this->secondaryLinks);
+        new SiteHeader($this->title, null, $this->secondaryLinks);
     }
 
     /**
@@ -98,7 +98,7 @@ final class SiteHeaderTest extends ViewModelTest
     public function secondary_links_must_be_supplied()
     {
         $this->expectException(TypeError::class);
-        new SiteHeader($this->logo, $this->primaryLinks, null);
+        new SiteHeader($this->title, $this->primaryLinks, null);
     }
 
     public function viewModelProvider() : array

--- a/tests/src/ViewModel/SiteHeaderTitleTest.php
+++ b/tests/src/ViewModel/SiteHeaderTitleTest.php
@@ -2,17 +2,17 @@
 
 namespace tests\eLife\Patterns\ViewModel;
 
-use eLife\Patterns\ViewModel\SiteHeaderLogo;
+use eLife\Patterns\ViewModel\SiteHeaderTitle;
 use InvalidArgumentException;
 
-final class SiteHeaderLogoTest extends ViewModelTest
+final class SiteHeaderTitleTest extends ViewModelTest
 {
     /**
      * @test
      */
     public function it_has_data()
     {
-        $siteHeaderLogo = new SiteHeaderLogo('/home/page/path');
+        $siteHeaderLogo = new SiteHeaderTitle('/home/page/path');
         $this->assertSame('/home/page/path', $siteHeaderLogo['homePagePath']);
     }
 
@@ -22,18 +22,19 @@ final class SiteHeaderLogoTest extends ViewModelTest
     public function home_page_path_must_not_be_blank()
     {
         $this->expectException(InvalidArgumentException::class);
-        new SiteHeaderLogo('');
+        new SiteHeaderTitle('');
     }
 
     public function viewModelProvider() : array
     {
         return [
-            [new SiteHeaderLogo('/home/page/path')],
+            'minimum' => [new SiteHeaderTitle('/home/page/path')],
+            'complete' => [new SiteHeaderTitle('/home/page/path', true, true)],
         ];
     }
 
     protected function expectedTemplate() : string
     {
-        return 'resources/templates/site-header-logo.mustache';
+        return 'resources/templates/site-header-title.mustache';
     }
 }


### PR DESCRIPTION
I have run https://alfred.elifesciences.org/job/dependencies-patterns-php-update-pattern-library/601/ which resulted in this pull request.