### PR TITLE
fix: fixes to support successful test suite run on PHP 7.4

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -22,7 +22,7 @@
         "mustache/mustache": "^2.5"
     },
     "require-dev": {
-        "justinrainbow/json-schema": "^5.0",
+        "justinrainbow/json-schema": "^5.1",
         "php-jsonpointer/php-jsonpointer": "^1.0",
         "phpunit/phpunit": "^5.2",
         "phpspec/prophecy": "^1.10",
@@ -30,7 +30,7 @@
         "symfony/finder": "^3.0",
         "symfony/process": "^3.0",
         "symfony/yaml": "^3.1",
-        "twig/twig": "^2.0",
+        "twig/twig": "^2.10",
         "squizlabs/php_codesniffer": "^3.5"
     },
     "suggest": {

--- a/src/ViewModel/TextField.php
+++ b/src/ViewModel/TextField.php
@@ -83,8 +83,6 @@ final class TextField implements ViewModel
         string $state = null,
         MessageGroup $messageGroup = null
     ) {
-        Assertion::eq(null, $formFieldInfoLink['alignLeft'] ?? null);
-
         return new static('email', $label, $id, $name, $placeholder, $required, $disabled, null, null, $autofocus, $value, $state, $messageGroup, $formFieldInfoLink);
     }
 

--- a/src/ViewModel/TextField.php
+++ b/src/ViewModel/TextField.php
@@ -83,7 +83,7 @@ final class TextField implements ViewModel
         string $state = null,
         MessageGroup $messageGroup = null
     ) {
-        Assertion::eq(null, $formFieldInfoLink['alignLeft']);
+        Assertion::eq(null, $formFieldInfoLink['alignLeft'] ?? null);
 
         return new static('email', $label, $id, $name, $placeholder, $required, $disabled, null, null, $autofocus, $value, $state, $messageGroup, $formFieldInfoLink);
     }


### PR DESCRIPTION
- Upgrade minimum dependencies for twig and json-schema. These were the minimum versions that support fixes necessary for PHP 7.4
- fix a treating null array-access as null deprecation issue in eLife\Patterns\ViewModel\TextField by using null-coalesce (available since PHP 7.0)