### PR TITLE
Updated pattern-library to 4d541e4: Bug: added link. to tag as was missing for image link

### DIFF
--- a/resources/templates/highlight-item.mustache
+++ b/resources/templates/highlight-item.mustache
@@ -1,6 +1,6 @@
 <li class="highlight-item">
    {{#image}}
-   <a href="{{url}}" class="highlight-item__picture-wrapper">
+   <a href="{{link.url}}" class="highlight-item__picture-wrapper">
      <picture class='highlight-item__picture'>
          {{#sources}}
          <source srcset='{{srcset}}'


### PR DESCRIPTION
I have run https://alfred.elifesciences.org/job/dependencies/job/dependencies-patterns-php-update-pattern-library/739/ which resulted in this pull request.